### PR TITLE
Feat/plano 3 settings crud

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Força LF em todo arquivo texto. Evita falsos positivos de "modified"
+# em Windows quando ferramentas (cargo/tauri-build/ts-rs/vite) reescrevem
+# arquivos em LF enquanto o autocrlf local esperava CRLF.
+* text=auto eol=lf
+
+# Scripts que SÓ funcionam com CRLF (Windows)
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Binários — nunca converter
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.icns binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.pdf binary

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+tmp/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ The golden fence: **Rust never draws UI; frontend never touches disk or OS APIs.
 - **Config file is the source of truth** at startup. The app reads `%APPDATA%\DonutTabs\config.json` (Windows), `~/Library/Application Support/DonutTabs/config.json` (macOS), or `~/.config/DonutTabs/config.json` (Linux). Mutations always go through `config::io::save_atomic` (validate → write `.tmp` → rename); no other code writes directly.
 - **Every `Config` mutation broadcasts.** `save_tab` and `delete_tab` emit `CONFIG_CHANGED_EVENT` on success. Future write commands must follow the same pattern: validate + atomic-write + emit, with in-memory rollback (reload from disk) if the write fails.
 - **Text in code vs in UI**: internal logs and dev-facing error context stay in English technical form; anything the user reads goes through `t()` from `react-i18next`. No hardcoded Portuguese (or English) UI strings in JSX or in `AppError` payloads. New Rust errors use `AppError::config/launcher/window/shortcut` with `snake_case` codes and a matching entry in both `src/locales/pt-BR.json` and `src/locales/en.json` (under `errors.{kind}.{camelCode}`).
+- **Temporary files go in `tmp/`**: any throwaway artifact (scratch notes, ad-hoc scripts, generated logs, PR bodies, debug dumps, one-off reproducers) must be written under the repo-root `tmp/` folder, which is gitignored via `tmp/*`. Never drop temporary files at the repo root, inside `src/`, `src-tauri/`, or `docs/`. Create the directory if it doesn't exist yet.
 
 ## CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Before making non-trivial changes, read:
 - [docs/Plano.md](docs/Plano.md) — design spec with the "why" of every architectural decision, the phased roadmap, and extensibility hooks in the schema
 - [docs/plans/01-fundacao.md](docs/plans/01-fundacao.md) — the executed implementation plan for the current MVP (Plano 1)
 - [docs/plans/02-i18n.md](docs/plans/02-i18n.md) — the executed implementation plan for i18n + structured AppError (Plano 2)
+- [docs/plans/03-settings-crud.md](docs/plans/03-settings-crud.md) — the executed implementation plan for the Settings window / CRUD (Plano 3)
 - [docs/qa-smoke.md](docs/qa-smoke.md) — manual smoke checklist for the three OSes
 
 The user speaks Portuguese; all docs, commit messages, and user-facing strings in the app should be in Portuguese.
@@ -60,7 +61,7 @@ Single process with **three logical pieces**:
 
 1. **Rust core** (`src-tauri/src/`) — all OS-level concerns: global shortcut, tray icon, window creation (transparent/undecorated/always-on-top), URL opening, config IO. Never draws UI.
 2. **Donut webview** (`src/entry/donut.tsx` → `src/donut/*`) — transparent window rendered at cursor position, shows the SVG donut, captures hover/click, calls Rust commands via IPC.
-3. **Settings webview** (not yet implemented — Plano 3) — normal decorated window with the CRUD UI for tabs and preferences.
+3. **Settings webview** (`src/entry/settings.tsx` → `src/settings/*`) — decorated, resizable window with `<TabList>` + `<TabEditor>` for CRUD. Loads config via IPC and listens to `config-changed`; the donut mirrors the same event so both windows stay in sync without polling. Preferences UI (shortcut + appearance) lands in Plano 4.
 
 Rust and frontend communicate via **typed Tauri commands** through `src/core/ipc.ts`. Types in `src/core/types/` are **auto-generated** from Rust by `ts-rs` — never hand-edit them.
 
@@ -70,12 +71,13 @@ The golden fence: **Rust never draws UI; frontend never touches disk or OS APIs.
 
 - `config/schema.rs` — `Config`, `Tab`, `Item`, the enums. All derive `Serialize + Deserialize + PartialEq + TS` with `#[serde(rename_all = "camelCase")]`. `Item` is a **tagged union** (`#[serde(tag = "kind")]`) designed for future `kind: "file" | "app" | "script" | "folder"` variants (Fase 3). Do **not** flatten it into an untagged enum. `Appearance.language` is `Language::{Auto, PtBr, En}`, consumed by `src/core/i18n.ts` at bootstrap.
 - `config/validate.rs` — semantic rules: items_per_page range, at least one of `name`/`icon` per tab, URL parseability, unique ids. First-error semantics (not accumulating). Logic-level tests. Errors emit structured codes (e.g. `items_per_page_out_of_range`, `invalid_url`), never free-form strings.
-- `config/io.rs` — read-only today (`load_from_path` with default fallback, recovery errors on malformed JSON). `appearance.language` uses `#[serde(default)]` so configs written before Plano 2 still load. Plano 3 adds atomic writes.
+- `config/io.rs` — `load_from_path` (default fallback, recovery error on malformed JSON) **and** `save_atomic` (validates first, writes to `config.json.tmp`, then `rename`). `appearance.language` uses `#[serde(default)]` so configs written before Plano 2 still load.
 - `launcher/` — `Opener` trait for testability + `TauriOpener<'a, R>` impl that delegates to the `opener` plugin. `launch_tab` accumulates per-URL failures and only errors if **all** items failed (`all_items_failed` code).
-- `tray/` — tray icon with "Abrir donut" / "Sair" menu. Triggers `donut_window::show` on menu click.
+- `tray/` — tray icon with "Abrir donut" / "Configurações" / "Sair". The "Configurações" item calls `settings_window::show`.
 - `shortcut/` — registers the global shortcut from config; its handler calls `donut_window::show`.
 - `donut_window/` — creates the window (transparent, undecorated, always-on-top, `skip_taskbar`, no shadow) and positions it at the cursor using the `mouse_position` crate, taking DPI into account via `scale_factor()`. Caches the window after first creation so subsequent `show` calls are instant.
-- `commands.rs` — `AppState { config: RwLock<Config>, config_path }` + the three Tauri commands (`get_config`, `open_tab`, `hide_donut`). `config_path` is marked `#[allow(dead_code)]` — reserved for Plano 3 save/delete.
+- `settings_window/` — creates/focuses/closes the decorated Settings window (label `settings`, min size 720×520, initial 960×640). Consumed by the `open_settings` / `close_settings` commands and by the tray.
+- `commands.rs` — `AppState { config: RwLock<Config>, config_path }` + Tauri commands `get_config`, `open_tab`, `hide_donut`, `save_tab`, `delete_tab`, `open_settings`, `close_settings`. `save_tab`/`delete_tab` call `apply_save`/`apply_delete` (pure, tested), then `save_atomic`; on IO failure, in-memory state is rolled back by reloading from disk. Successful mutations emit `CONFIG_CHANGED_EVENT` ("config-changed") with the new `Config` as payload.
 - `errors.rs` — `AppError` with `#[serde(tag = "kind", content = "message")]`, content shape `{ code: String, context: BTreeMap<String, String> }`. Helpers `AppError::config/launcher/window/shortcut("code", &[("k", v)])` for ergonomic construction. Frontend maps `code` → translation key via `src/core/errors.ts`.
 - `lib.rs` — orchestration: loads config, registers commands, sets up tray + shortcut, pre-warms the donut window.
 
@@ -83,23 +85,26 @@ The golden fence: **Rust never draws UI; frontend never touches disk or OS APIs.
 
 - `src/donut/geometry.ts` — pure math (SVG arc paths, polar→slice hit-testing). No React, fully unit-testable.
 - `src/donut/useSliceHighlight.ts` — hook converting `MouseEvent` into the currently-hovered slice index, or `null` if in the center dead zone or beyond the outer ring.
-- `src/donut/{Slice,CenterCircle,Donut}.tsx` — presentational SVG components. `CenterCircle` currently shows a gear ⚙ (will open Settings in Plano 3) and a profile glyph 👤 (right half reserved for the profile switcher — see Fase 2 in `Plano.md`).
+- `src/donut/{Slice,CenterCircle,Donut}.tsx` — presentational SVG components. The ⚙ on `CenterCircle`'s left half is now clickable (opens Settings); the right half still shows the profile glyph 👤 reserved for the profile switcher (Plano 6). The donut passes `onOpenSettings` through.
 - `src/core/i18n.ts` — `react-i18next` init. `resolveLanguage()` combines `appearance.language` from config with `navigator.language`; `initI18n()` bootstraps the global instance; `createI18n()` creates isolated instances for tests. Locale JSON lives in `src/locales/{pt-BR,en}.json`.
 - `src/core/errors.ts` — `translateAppError(err, t)` converts the Rust `AppError` payload into a localized string, trying `errors.{kind}.{camelCode}` → `errors.{kind}.unknown` → `errors.fallback`.
-- `src/entry/donut.tsx` — window entrypoint: bootstraps i18next from config before React mounts, wires ESC / click-outside / window-blur → `hideDonut`, delegates selection to `openTab`, and surfaces launch failures as a dismissible localized toast.
+- `src/core/ipc.ts` — typed wrappers for all commands plus the `CONFIG_CHANGED_EVENT` constant that both windows use to subscribe via `@tauri-apps/api/event`'s `listen`.
+- `src/entry/donut.tsx` — window entrypoint: bootstraps i18next from config before React mounts, wires ESC / click-outside / window-blur → `hideDonut`, delegates selection to `openTab`, listens for `config-changed` to refresh tabs, surfaces launch failures as a dismissible localized toast, and routes gear clicks to `openSettings` + `hideDonut`.
+- `src/entry/settings.tsx` + `src/settings/*` — the Settings window. `SettingsApp` owns selection state between `TabList` (sidebar) and `TabEditor` (form). `useConfig` is the single source of truth for config: loads on mount via `get_config` and subscribes to `config-changed`, with `saveTab`/`deleteTab` helpers that round-trip through IPC and apply the returned snapshot. `TabEditor` validates name-or-icon / at-least-one-URL / `new URL(...)` client-side, then submits; server-side `AppError`s render via `translateAppError`. Delete passes through `window.confirm`.
 
 ### Tauri config gotchas (already applied — do not undo)
 
 - `tauri.conf.json`: `app.windows = []` (windows are created programmatically), `app.macOSPrivateApi = true` for transparency on macOS
 - `src-tauri/Cargo.toml`: `tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }` — both flags are **required** by the matching conf/API usage
-- `capabilities/default.json` lists permissions for only the `donut` window; global-shortcut and opener plugins are gated through `global-shortcut:default` / `opener:default` + `opener:allow-open-url`
+- `capabilities/default.json` lists permissions for both `donut` and `settings` windows; global-shortcut and opener plugins are gated through `global-shortcut:default` / `opener:default` + `opener:allow-open-url`; `core:event:default` enables `listen`/`emit` for the `config-changed` event that syncs both windows
 
 ## Conventions
 
 - **TDD** for pure logic (`config/*`, `launcher`, `geometry`, `useSliceHighlight`, `Donut`). Write the failing test first, then the minimum code to pass. Don't backfill tests onto already-written code unless the task says so.
 - **Small commits with scoped messages**: `feat(config): ...`, `chore(tray): ...`, `fix(config): ...`, `ci: ...`, `docs(plan): ...`. One task = one logical concern = one commit (Cargo.lock updates piggy-back on the commit that changed Cargo.toml).
 - **Schema-first, IPC-typed**: any new frontend↔Rust data shape lives as a Rust struct with `#[derive(TS)]`, generated into TS, and consumed through `src/core/ipc.ts`. Don't duplicate types by hand.
-- **Config file is the source of truth** at startup. The app reads `%APPDATA%\DonutTabs\config.json` (Windows), `~/Library/Application Support/DonutTabs/config.json` (macOS), or `~/.config/DonutTabs/config.json` (Linux). Plano 3 adds write-back with atomic rename (`config.json.tmp` → `rename`).
+- **Config file is the source of truth** at startup. The app reads `%APPDATA%\DonutTabs\config.json` (Windows), `~/Library/Application Support/DonutTabs/config.json` (macOS), or `~/.config/DonutTabs/config.json` (Linux). Mutations always go through `config::io::save_atomic` (validate → write `.tmp` → rename); no other code writes directly.
+- **Every `Config` mutation broadcasts.** `save_tab` and `delete_tab` emit `CONFIG_CHANGED_EVENT` on success. Future write commands must follow the same pattern: validate + atomic-write + emit, with in-memory rollback (reload from disk) if the write fails.
 - **Text in code vs in UI**: internal logs and dev-facing error context stay in English technical form; anything the user reads goes through `t()` from `react-i18next`. No hardcoded Portuguese (or English) UI strings in JSX or in `AppError` payloads. New Rust errors use `AppError::config/launcher/window/shortcut` with `snake_case` codes and a matching entry in both `src/locales/pt-BR.json` and `src/locales/en.json` (under `errors.{kind}.{camelCode}`).
 
 ## CI
@@ -114,15 +119,17 @@ The golden fence: **Rust never draws UI; frontend never touches disk or OS APIs.
 
 Docs-only changes are skipped via `paths-ignore` (`**/*.md`, `docs/**`, `LICENSE*`, `.gitignore`). Linux is the primary test target; macOS/Windows mainly verify cross-platform compilation of the same tests.
 
-**Clippy is currently run without `-D warnings`** because the MVP intentionally leaves some dead-code warnings for items consumed in Plano 3 (e.g., `AppState::config_path`, `AppError::shortcut` helper). When Plano 3 wires these up, tighten to `-D warnings`.
+**Clippy is currently run without `-D warnings`** because the MVP intentionally leaves one harmless dead-code warning (`AppError::shortcut` helper — consumed in Plano 4). When Plano 4 wires it up, tighten to `-D warnings`. `AppState::config_path` is now live and no longer marked `#[allow(dead_code)]`.
 
-## Looking ahead to Plano 3 and beyond
+## Looking ahead to Plano 4 and beyond
 
-Plano 2 is done: i18n (`react-i18next` with `pt-BR` + `en`), `appearance.language` active, and `AppError` is fully structured (`code` + `context`). Plano 3 builds on this base.
+Plano 3 is done: Settings window with `<TabList>` + `<TabEditor>` + CRUD via `save_tab` / `delete_tab`, `config::io::save_atomic`, and `config-changed` event synchronizing the donut and the Settings in real time.
 
-Read `Plano.md` section 8.2 before starting. Key decisions still pending:
+Next slices (in order):
 
-1. **Settings window** (`src/entry/settings.tsx` + `src/settings/*`): `<TabList>`, `<TabEditor>`, `<ShortcutRecorder>`, `<AppearanceSection>` (including a language selector that calls `changeLanguage` from `src/core/i18n.ts`). New Rust commands: `save_tab`, `delete_tab`, `set_shortcut`. `config/io.rs` gains atomic write (`config.json.tmp` → `rename`). Event `config-changed` emits from Rust so the donut re-reads state when Settings mutates.
-2. **Fatia "+"** on the donut, pagination + hover-hold → editar/excluir, per Seção 5 of `Plano.md`.
-3. **Perfis** (Plano 4, already designed): right half of the center circle becomes a profile switcher; schema gains `profiles[]` with a v1→v2 migration.
-4. Any new user-facing string must have keys in both locale files; any new `AppError` code must have a translation under `errors.{kind}.{camelCode}`. The `errors.{kind}.unknown` fallback exists precisely to catch missed ones — if you see it surfaced in dev, add the specific key before merging.
+1. **Plano 4 — Settings preferences**: `<ShortcutRecorder>` (captures key combos, rejects reserved keys), `<AppearanceSection>` with theme + language selectors (the language select calls `changeLanguage` already exported from `src/core/i18n.ts`; wire a listener on `config-changed` to retranslate `document.title`). New Rust command `set_shortcut` with conflict-aware registration. Tighten clippy to `-D warnings` once `AppError::shortcut` is consumed.
+2. **Plano 5 — Donut gestures**: fatia "+", paginação com roda + indicadores, hover-hold → editar/excluir (abre o TabEditor na aba correspondente).
+3. **Plano 6 — Perfis**: schema v2 + migração v1→v2 + profile switcher no lado direito do centro (atalho e tema por perfil).
+4. **Plano 7 — Polimento**: menu de contexto nas fatias, favicons / Lucide, drag-and-drop para reordenar, autostart.
+
+Any new user-facing string must have keys in both locale files; any new `AppError` code must have a translation under `errors.{kind}.{camelCode}`. The `errors.{kind}.unknown` fallback exists precisely to catch missed ones — if you see it surfaced in dev, add the specific key before merging.

--- a/docs/plans/03-settings-crud.md
+++ b/docs/plans/03-settings-crud.md
@@ -1,0 +1,2050 @@
+# DonutTabs — Plano 3: Janela Settings (CRUD de abas)
+
+> **Para agentes executores:** SUB-SKILL OBRIGATÓRIA: Use `superpowers:subagent-driven-development` (recomendada) ou `superpowers:executing-plans` para implementar este plano tarefa-a-tarefa. Passos usam checkbox (`- [ ]`) para rastreamento.
+
+**Meta:** Entregar uma janela de configurações decorada que permita ao usuário **criar, editar e excluir abas** pela UI, substituindo a edição manual do `config.json`. Inclui as peças de infraestrutura que as próximas fases (preferências, "+" no donut, perfis) vão consumir: write atômica em disco, evento `config-changed` que sincroniza janelas abertas, e a fronteira de comandos `save_tab` / `delete_tab`.
+
+**Arquitetura:** Adiciona uma segunda webview (`settings`) no mesmo projeto Vite (multi-entry). A janela é normal (decorada, redimensionável). A janela do donut segue existindo inalterada em termos de UX; passa a escutar `config-changed` para refletir mudanças em tempo real. O Rust ganha um módulo `settings_window/` e os comandos `save_tab`, `delete_tab`, `open_settings` e `close_settings`, todos consumindo o `AppState` já existente. `config/io.rs` ganha `save_atomic` (escreve em `config.json.tmp` + `rename`).
+
+**Stack adicional:** nenhuma crate nova. Frontend usa apenas React + i18next já instalados; o formulário é nativo (sem lib de forms).
+
+**Fora desta slice (vem em planos seguintes):**
+- `ShortcutRecorder`, `AppearanceSection`, `set_shortcut` (Plano 4 — preferências).
+- Fatia "+" no donut, paginação, hover-hold editar/excluir (Plano 5 — gestos do donut).
+- Perfis, schema v2 (Plano 6).
+- Drag-and-drop para reordenar, menu de contexto, favicons, autostart (Plano 7).
+
+---
+
+## Pré-requisitos (estado atual após Plano 2 mergeado)
+
+- [src-tauri/src/commands.rs](../../src-tauri/src/commands.rs) — `AppState { config: RwLock<Config>, config_path }`. `config_path` já está capturado, só falta usá-lo. Comandos existentes: `get_config`, `open_tab`, `hide_donut`.
+- [src-tauri/src/config/io.rs](../../src-tauri/src/config/io.rs) — apenas `load_from_path`. Sem escrita.
+- [src-tauri/src/errors.rs](../../src-tauri/src/errors.rs) — `AppError { code, context }` com helpers `AppError::config/launcher/window/shortcut`.
+- [src-tauri/src/tray/mod.rs](../../src-tauri/src/tray/mod.rs) — menu com "Abrir donut" / "Sair". Sem "Configurações".
+- [src-tauri/tauri.conf.json](../../src-tauri/tauri.conf.json) — `app.windows: []`; janelas criadas programaticamente.
+- [src-tauri/capabilities/default.json](../../src-tauri/capabilities/default.json) — `windows: ["donut"]`; sem permissões de evento.
+- [vite.config.ts](../../vite.config.ts) — multi-entry já estabelecido (`donut`); só precisa adicionar `settings`.
+- [src/entry/donut.tsx](../../src/entry/donut.tsx) — faz bootstrap do i18n e renderiza o donut. Ainda não escuta `config-changed`.
+- [src/donut/CenterCircle.tsx](../../src/donut/CenterCircle.tsx) — engrenagem ⚙ é placeholder visual (sem click handler).
+- [src/locales/{pt-BR,en}.json](../../src/locales/) — contêm chaves de erro; nenhuma chave de UI do Settings ainda.
+
+---
+
+## Estrutura de arquivos
+
+### Novos arquivos
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `settings.html` | HTML entrypoint da janela Settings (análogo a `donut.html`) |
+| `src/entry/settings.tsx` | Bootstrap do i18n + mount do `<SettingsApp>` |
+| `src/settings/SettingsApp.tsx` | Layout da janela (sidebar/lista + detalhe) + estado global da config |
+| `src/settings/TabList.tsx` | Lista de abas com botão "Adicionar aba" e seleção |
+| `src/settings/TabEditor.tsx` | Formulário (name, icon, openMode, lista de URLs) |
+| `src/settings/UrlListEditor.tsx` | Sub-componente com input + ✕ por URL + botão "Adicionar URL" |
+| `src/settings/useConfig.ts` | Hook que carrega `get_config`, escuta `config-changed`, expõe `saveTab`/`deleteTab` |
+| `src/settings/__tests__/TabEditor.test.tsx` | Validações de formulário |
+| `src/settings/__tests__/TabList.test.tsx` | Seleção e empty state |
+| `src/settings/__tests__/useConfig.test.tsx` | Reação a `config-changed` (mock de listen) |
+| `src-tauri/src/settings_window/mod.rs` | `show()` / `focus()` / `close()` + criação da `WebviewWindow` |
+| `src-tauri/capabilities/settings.json` | Permissões específicas da janela Settings (events, window sizing) |
+
+### Arquivos modificados
+
+| Arquivo | Mudança |
+|---|---|
+| `vite.config.ts` | Adicionar `settings: resolve(__dirname, "settings.html")` nos inputs |
+| `src-tauri/tauri.conf.json` | (sem mudança — janelas continuam criadas via código) |
+| `src-tauri/capabilities/default.json` | Adicionar `"settings"` em `windows`; permissões `core:event:default` para ambas |
+| `src-tauri/src/config/io.rs` | `save_atomic(path, &Config)` com write atômica + testes |
+| `src-tauri/src/commands.rs` | `save_tab`, `delete_tab`, `open_settings`, `close_settings`; emit de `config-changed` |
+| `src-tauri/src/lib.rs` | Registrar novos comandos; declarar módulo `settings_window` |
+| `src-tauri/src/tray/mod.rs` | Adicionar item "Configurações" antes de "Sair" |
+| `src/core/ipc.ts` | Wrappers tipados `saveTab`, `deleteTab`, `openSettings`, `closeSettings` |
+| `src/donut/CenterCircle.tsx` | Torna a engrenagem ⚙ clicável → `openSettings` + `hideDonut` |
+| `src/entry/donut.tsx` | Escuta `config-changed` e atualiza `config` state |
+| `src/locales/pt-BR.json` | Novas chaves `settings.*` + erros novos |
+| `src/locales/en.json` | Idem |
+| `CLAUDE.md` | Atualizar "Looking ahead" → Plano 4 em diante |
+
+---
+
+## Tarefas
+
+### Task 1: Multi-entrypoint — `settings.html` e Vite input
+
+**Arquivos:**
+- Criar: `settings.html`
+- Modificar: `vite.config.ts`
+
+- [ ] **Step 1.1 — Criar `settings.html`**
+
+Decorado, com `lang="pt-BR"` (o i18n troca a semântica interna; o atributo HTML inicial apenas indica a preferência padrão e pode ficar estático). Fundo opaco (não-transparente, diferente do donut):
+
+```html
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DonutTabs — Configurações</title>
+    <style>
+      html, body { margin: 0; padding: 0; height: 100%; background: #0f1320; color: #dde; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+      #root { width: 100vw; height: 100vh; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/entry/settings.tsx"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 1.2 — Atualizar `vite.config.ts`**
+
+```ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  clearScreen: false,
+  server: { port: 1420, strictPort: true },
+  build: {
+    rollupOptions: {
+      input: {
+        donut: resolve(__dirname, "donut.html"),
+        settings: resolve(__dirname, "settings.html"),
+      },
+    },
+  },
+});
+```
+
+- [ ] **Step 1.3 — Stub do entrypoint para o build não quebrar**
+
+Criar `src/entry/settings.tsx` com o mínimo renderizável (substituído na Task 10):
+
+```tsx
+import { createRoot } from "react-dom/client";
+
+createRoot(document.getElementById("root")!).render(
+  <div style={{ padding: 24 }}>DonutTabs — Settings (wip)</div>,
+);
+```
+
+- [ ] **Step 1.4 — `npm run build` para verificar**
+
+```bash
+npm run build
+```
+
+Esperado: dois bundles emitidos (`dist/donut.html` e `dist/settings.html`).
+
+- [ ] **Step 1.5 — Commit**
+
+```bash
+git add settings.html vite.config.ts src/entry/settings.tsx
+git commit -m "chore(settings): add settings.html entry and vite multi-input"
+```
+
+---
+
+### Task 2: Módulo Rust `settings_window/` e permissões
+
+**Arquivos:**
+- Criar: `src-tauri/src/settings_window/mod.rs`
+- Criar: `src-tauri/capabilities/settings.json`
+- Modificar: `src-tauri/capabilities/default.json`
+- Modificar: `src-tauri/src/lib.rs`
+
+- [ ] **Step 2.1 — Criar `src-tauri/src/settings_window/mod.rs`**
+
+```rust
+use crate::errors::{AppError, AppResult};
+use tauri::{AppHandle, Manager, Runtime, WebviewUrl, WebviewWindowBuilder};
+
+pub const SETTINGS_LABEL: &str = "settings";
+const SETTINGS_MIN_SIZE: (f64, f64) = (720.0, 520.0);
+const SETTINGS_INITIAL_SIZE: (f64, f64) = (960.0, 640.0);
+
+pub fn show<R: Runtime>(app: &AppHandle<R>) -> AppResult<()> {
+    if let Some(window) = app.get_webview_window(SETTINGS_LABEL) {
+        window
+            .show()
+            .map_err(|e| AppError::window("window_show_failed", &[("reason", e.to_string())]))?;
+        window.set_focus().map_err(|e| {
+            AppError::window("window_set_focus_failed", &[("reason", e.to_string())])
+        })?;
+        return Ok(());
+    }
+
+    WebviewWindowBuilder::new(app, SETTINGS_LABEL, WebviewUrl::App("settings.html".into()))
+        .title("DonutTabs — Configurações")
+        .inner_size(SETTINGS_INITIAL_SIZE.0, SETTINGS_INITIAL_SIZE.1)
+        .min_inner_size(SETTINGS_MIN_SIZE.0, SETTINGS_MIN_SIZE.1)
+        .resizable(true)
+        .decorations(true)
+        .visible(true)
+        .build()
+        .map_err(|e| AppError::window("window_build_failed", &[("reason", e.to_string())]))?;
+
+    Ok(())
+}
+
+pub fn close<R: Runtime>(app: &AppHandle<R>) -> AppResult<()> {
+    if let Some(window) = app.get_webview_window(SETTINGS_LABEL) {
+        window
+            .close()
+            .map_err(|e| AppError::window("window_close_failed", &[("reason", e.to_string())]))?;
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 2.2 — Declarar o módulo em `lib.rs`**
+
+```rust
+mod settings_window;
+```
+
+- [ ] **Step 2.3 — Atualizar `capabilities/default.json`**
+
+```json
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Capabilities padrão do DonutTabs",
+  "windows": ["donut", "settings"],
+  "permissions": [
+    "core:default",
+    "core:window:allow-close",
+    "core:window:allow-hide",
+    "core:window:allow-show",
+    "core:window:allow-set-focus",
+    "core:event:default",
+    "global-shortcut:default",
+    "opener:default",
+    "opener:allow-open-url"
+  ]
+}
+```
+
+`core:event:default` cobre `emit`/`listen` em ambas as janelas. `settings.json` separado não é necessário ainda — entra no Plano 4 se houver permissão exclusiva.
+
+- [ ] **Step 2.4 — Build de sanidade**
+
+```bash
+cd src-tauri && cargo check && cd ..
+```
+
+- [ ] **Step 2.5 — Commit**
+
+```bash
+git add src-tauri/src/settings_window/mod.rs src-tauri/src/lib.rs src-tauri/capabilities/default.json
+git commit -m "feat(settings-window): module + capabilities for the settings webview"
+```
+
+---
+
+### Task 3: Write atômica em `config/io.rs`
+
+**Arquivos:**
+- Modificar: `src-tauri/src/config/io.rs`
+
+- [ ] **Step 3.1 — Escrever testes (FALHAM — função não existe)**
+
+No `#[cfg(test)] mod tests` de `src-tauri/src/config/io.rs`, adicionar:
+
+```rust
+#[test]
+fn save_atomic_writes_then_renames() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("config.json");
+    let cfg = Config::default();
+
+    save_atomic(&path, &cfg).unwrap();
+
+    assert!(path.exists());
+    // Nenhum .tmp sobra após sucesso.
+    assert!(!path.with_extension("json.tmp").exists());
+
+    let loaded = load_from_path(&path).unwrap();
+    assert_eq!(loaded, cfg);
+}
+
+#[test]
+fn save_atomic_overwrites_existing_file() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("config.json");
+    let cfg1 = Config::default();
+    save_atomic(&path, &cfg1).unwrap();
+
+    let mut cfg2 = cfg1.clone();
+    cfg2.pagination.items_per_page = 7;
+    save_atomic(&path, &cfg2).unwrap();
+
+    let loaded = load_from_path(&path).unwrap();
+    assert_eq!(loaded.pagination.items_per_page, 7);
+}
+
+#[test]
+fn save_atomic_creates_parent_dir_if_missing() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("nested").join("sub").join("config.json");
+    let cfg = Config::default();
+    save_atomic(&path, &cfg).unwrap();
+    assert!(path.exists());
+}
+
+#[test]
+fn save_atomic_rejects_invalid_config() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("config.json");
+    let mut cfg = Config::default();
+    cfg.pagination.items_per_page = 99;
+    let err = save_atomic(&path, &cfg).unwrap_err();
+    assert!(matches!(err, AppError::Config { .. }));
+    // Arquivo não foi criado porque falhou antes da escrita.
+    assert!(!path.exists());
+}
+
+#[test]
+fn save_atomic_leaves_previous_file_on_serialization_success() {
+    // Sanity check do contrato: entre abrir o .tmp e o rename, a versão antiga
+    // permanece acessível. Aqui só verificamos que o rename acontece no fim.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("config.json");
+    let cfg1 = Config::default();
+    save_atomic(&path, &cfg1).unwrap();
+    let content_before = std::fs::read_to_string(&path).unwrap();
+
+    let cfg2 = cfg1.clone();
+    save_atomic(&path, &cfg2).unwrap();
+    let content_after = std::fs::read_to_string(&path).unwrap();
+    assert_eq!(content_before, content_after);
+}
+```
+
+Rodar:
+
+```bash
+cd src-tauri && cargo test --lib config::io && cd ..
+```
+
+Esperado: compile-error (`save_atomic` não existe).
+
+- [ ] **Step 3.2 — Implementar `save_atomic`**
+
+Em `src-tauri/src/config/io.rs`, adicionar:
+
+```rust
+use std::io::Write;
+
+/// Grava a config em disco de forma atômica: escreve em `<path>.tmp` e depois
+/// renomeia para `<path>`. Valida antes de escrever — falha aborta sem
+/// tocar no arquivo existente.
+pub fn save_atomic(path: &Path, config: &Config) -> AppResult<()> {
+    validate(config)?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let tmp_path = path.with_extension("json.tmp");
+    let json = serde_json::to_string_pretty(config)?;
+
+    {
+        let mut file = std::fs::File::create(&tmp_path)?;
+        file.write_all(json.as_bytes())?;
+        file.sync_all().ok(); // best-effort; Windows não garante fsync de dir
+    }
+
+    std::fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+```
+
+Nota: o nome `.tmp` é determinístico (um por processo é suficiente — não há múltiplas escritas concorrentes no MVP). Se no futuro isso mudar, trocamos para `tempfile::NamedTempFile::persist`.
+
+- [ ] **Step 3.3 — Rodar tests**
+
+```bash
+cd src-tauri && cargo test --lib config::io && cd ..
+```
+
+Esperado: 9 testes passam (4 antigos + 5 novos).
+
+- [ ] **Step 3.4 — Commit**
+
+```bash
+git add src-tauri/src/config/io.rs
+git commit -m "feat(config): save_atomic writes to .tmp then renames"
+```
+
+---
+
+### Task 4: Comandos `save_tab`, `delete_tab`, `open_settings`, `close_settings` + evento `config-changed`
+
+**Arquivos:**
+- Modificar: `src-tauri/src/commands.rs`
+- Modificar: `src-tauri/src/lib.rs`
+- Modificar: `src-tauri/src/locales` (via testes — descrito abaixo)
+
+- [ ] **Step 4.1 — Escrever teste de lógica (FALHAM)**
+
+A lógica de mutação (inserir nova aba / atualizar existente / excluir) é pura — vale extrair para uma função testável. Criar em `src-tauri/src/commands.rs` no `#[cfg(test)]`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::schema::{Item, OpenMode, Tab};
+    use uuid::Uuid;
+
+    fn sample_tab(name: &str) -> Tab {
+        Tab {
+            id: Uuid::new_v4(),
+            name: Some(name.into()),
+            icon: None,
+            order: 0,
+            open_mode: OpenMode::ReuseOrNewWindow,
+            items: vec![Item::Url {
+                value: "https://example.com".into(),
+            }],
+        }
+    }
+
+    #[test]
+    fn apply_save_appends_new_tab_with_next_order() {
+        let mut cfg = Config::default();
+        cfg.tabs.push(sample_tab("A")); // order 0
+        cfg.tabs[0].order = 0;
+
+        let new_tab = sample_tab("B");
+        apply_save(&mut cfg, new_tab.clone());
+
+        assert_eq!(cfg.tabs.len(), 2);
+        assert_eq!(cfg.tabs[1].id, new_tab.id);
+        assert_eq!(cfg.tabs[1].order, 1);
+    }
+
+    #[test]
+    fn apply_save_updates_existing_tab_preserving_order() {
+        let mut cfg = Config::default();
+        let mut t = sample_tab("A");
+        t.order = 3;
+        let id = t.id;
+        cfg.tabs.push(t);
+
+        let mut updated = sample_tab("A-renamed");
+        updated.id = id;
+        updated.order = 99; // valor fornecido pelo cliente deve ser ignorado
+        apply_save(&mut cfg, updated);
+
+        assert_eq!(cfg.tabs.len(), 1);
+        assert_eq!(cfg.tabs[0].name.as_deref(), Some("A-renamed"));
+        assert_eq!(cfg.tabs[0].order, 3);
+    }
+
+    #[test]
+    fn apply_delete_removes_and_renormalizes_order() {
+        let mut cfg = Config::default();
+        let t0 = {
+            let mut t = sample_tab("A");
+            t.order = 0;
+            t
+        };
+        let t1 = {
+            let mut t = sample_tab("B");
+            t.order = 1;
+            t
+        };
+        let t2 = {
+            let mut t = sample_tab("C");
+            t.order = 2;
+            t
+        };
+        let id1 = t1.id;
+        cfg.tabs.push(t0);
+        cfg.tabs.push(t1);
+        cfg.tabs.push(t2);
+
+        apply_delete(&mut cfg, id1);
+
+        assert_eq!(cfg.tabs.len(), 2);
+        assert_eq!(cfg.tabs[0].order, 0);
+        assert_eq!(cfg.tabs[1].order, 1);
+        assert!(cfg.tabs.iter().all(|t| t.id != id1));
+    }
+
+    #[test]
+    fn apply_delete_on_missing_id_is_noop() {
+        let mut cfg = Config::default();
+        cfg.tabs.push(sample_tab("A"));
+        let before = cfg.tabs.len();
+
+        apply_delete(&mut cfg, Uuid::new_v4());
+
+        assert_eq!(cfg.tabs.len(), before);
+    }
+}
+```
+
+Rodar:
+
+```bash
+cd src-tauri && cargo test --lib commands && cd ..
+```
+
+Esperado: compile-error — `apply_save` / `apply_delete` não existem.
+
+- [ ] **Step 4.2 — Implementar `apply_save` / `apply_delete`**
+
+Em `src-tauri/src/commands.rs`:
+
+```rust
+use crate::config::io::save_atomic;
+
+fn apply_save(cfg: &mut Config, incoming: Tab) {
+    if let Some(existing) = cfg.tabs.iter_mut().find(|t| t.id == incoming.id) {
+        // Preserva a ordem antiga; tudo mais vem do payload.
+        let order = existing.order;
+        *existing = Tab {
+            order,
+            ..incoming
+        };
+    } else {
+        let order = cfg.tabs.len() as u32;
+        cfg.tabs.push(Tab { order, ..incoming });
+    }
+}
+
+fn apply_delete(cfg: &mut Config, id: Uuid) {
+    cfg.tabs.retain(|t| t.id != id);
+    for (i, t) in cfg.tabs.iter_mut().enumerate() {
+        t.order = i as u32;
+    }
+}
+```
+
+Adicionar ao topo do arquivo:
+
+```rust
+use crate::config::schema::Tab;
+use tauri::{Emitter, Manager}; // Manager já estava
+```
+
+- [ ] **Step 4.3 — Implementar comandos Tauri**
+
+Ainda em `commands.rs`:
+
+```rust
+pub const CONFIG_CHANGED_EVENT: &str = "config-changed";
+
+#[tauri::command]
+pub fn save_tab<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    tab: Tab,
+) -> Result<Config, AppError> {
+    let snapshot = {
+        let mut cfg = state.config.write().unwrap();
+        apply_save(&mut cfg, tab);
+        // Valida e persiste. Se falhar, revertemos o estado em memória.
+        if let Err(e) = save_atomic(&state.config_path, &cfg) {
+            // Recarrega do disco para que a memória reflita o último estado bom.
+            if let Ok(fresh) = crate::config::io::load_from_path(&state.config_path) {
+                *cfg = fresh;
+            }
+            return Err(e);
+        }
+        cfg.clone()
+    };
+
+    let _ = app.emit(CONFIG_CHANGED_EVENT, &snapshot);
+    Ok(snapshot)
+}
+
+#[tauri::command]
+pub fn delete_tab<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    tab_id: Uuid,
+) -> Result<Config, AppError> {
+    let snapshot = {
+        let mut cfg = state.config.write().unwrap();
+        apply_delete(&mut cfg, tab_id);
+        if let Err(e) = save_atomic(&state.config_path, &cfg) {
+            if let Ok(fresh) = crate::config::io::load_from_path(&state.config_path) {
+                *cfg = fresh;
+            }
+            return Err(e);
+        }
+        cfg.clone()
+    };
+
+    let _ = app.emit(CONFIG_CHANGED_EVENT, &snapshot);
+    Ok(snapshot)
+}
+
+#[tauri::command]
+pub fn open_settings<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), AppError> {
+    crate::settings_window::show(&app)
+}
+
+#[tauri::command]
+pub fn close_settings<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), AppError> {
+    crate::settings_window::close(&app)
+}
+```
+
+Remover o `#[allow(dead_code)]` acima de `config_path` em `AppState` — agora é consumido.
+
+- [ ] **Step 4.4 — Registrar os comandos em `lib.rs`**
+
+```rust
+.invoke_handler(tauri::generate_handler![
+    commands::get_config,
+    commands::open_tab,
+    commands::hide_donut,
+    commands::save_tab,
+    commands::delete_tab,
+    commands::open_settings,
+    commands::close_settings,
+])
+```
+
+- [ ] **Step 4.5 — Rodar todos os testes Rust**
+
+```bash
+cd src-tauri && cargo test --lib && cargo clippy --lib && cargo fmt --check && cd ..
+```
+
+Esperado: tudo verde (os testes de mutação pura rodam sem Tauri).
+
+- [ ] **Step 4.6 — Commit**
+
+```bash
+git add src-tauri/src/commands.rs src-tauri/src/lib.rs
+git commit -m "feat(commands): save_tab/delete_tab with atomic write and config-changed event"
+```
+
+---
+
+### Task 5: Tray ganha item "Configurações"
+
+**Arquivos:**
+- Modificar: `src-tauri/src/tray/mod.rs`
+- Modificar: `src/locales/{pt-BR,en}.json` (**nada** — o tray do Tauri exige strings no momento do build, fora do sistema i18n do React. Mantemos PT fixo; se em fases futuras o tray precisar alternar idioma, implementa-se troca dinâmica via evento)
+
+- [ ] **Step 5.1 — Adicionar item**
+
+Em `src-tauri/src/tray/mod.rs`, antes do `quit`:
+
+```rust
+let settings = MenuItem::with_id(app, "open_settings", "Configurações", true, None::<&str>)
+    .map_err(|e| AppError::window("tray_menu_item_failed", &[("reason", e.to_string())]))?;
+```
+
+Atualizar `Menu::with_items(app, &[&open, &settings, &quit])`.
+
+No `on_menu_event`, adicionar braço:
+
+```rust
+"open_settings" => {
+    let _ = crate::settings_window::show(app);
+}
+```
+
+- [ ] **Step 5.2 — Smoke local**
+
+```bash
+npm run tauri dev
+```
+
+Clicar no ícone do tray → "Configurações" → aparece a janela stub "DonutTabs — Settings (wip)". Fechar.
+
+- [ ] **Step 5.3 — Commit**
+
+```bash
+git add src-tauri/src/tray/mod.rs
+git commit -m "feat(tray): add Configurações menu item"
+```
+
+---
+
+### Task 6: IPC typed + strings traduzíveis do Settings
+
+**Arquivos:**
+- Modificar: `src/core/ipc.ts`
+- Modificar: `src/locales/pt-BR.json`, `src/locales/en.json`
+
+- [ ] **Step 6.1 — Atualizar `src/core/ipc.ts`**
+
+```ts
+import { invoke } from "@tauri-apps/api/core";
+import type { Config } from "./types/Config";
+import type { Tab } from "./types/Tab";
+
+export const ipc = {
+  getConfig: () => invoke<Config>("get_config"),
+  openTab: (tabId: string) => invoke<void>("open_tab", { tabId }),
+  hideDonut: () => invoke<void>("hide_donut"),
+  saveTab: (tab: Tab) => invoke<Config>("save_tab", { tab }),
+  deleteTab: (tabId: string) => invoke<Config>("delete_tab", { tabId }),
+  openSettings: () => invoke<void>("open_settings"),
+  closeSettings: () => invoke<void>("close_settings"),
+};
+
+export const CONFIG_CHANGED_EVENT = "config-changed";
+```
+
+- [ ] **Step 6.2 — Adicionar chaves nos locales**
+
+Em `src/locales/pt-BR.json`, adicionar à raiz:
+
+```json
+"settings": {
+  "title": "Configurações",
+  "tabs": {
+    "sectionTitle": "Abas",
+    "addTab": "Adicionar aba",
+    "empty": "Nenhuma aba cadastrada. Clique em \"Adicionar aba\" para começar.",
+    "selectPrompt": "Selecione uma aba para editar ou clique em \"Adicionar aba\"."
+  },
+  "editor": {
+    "newTabTitle": "Nova aba",
+    "name": "Nome",
+    "namePlaceholder": "Trabalho",
+    "icon": "Ícone",
+    "iconPlaceholder": "💼",
+    "iconHint": "Um emoji ou caractere curto. Nome ou ícone são obrigatórios.",
+    "openMode": "Modo de abertura",
+    "openModeReuseOrNewWindow": "Reutilizar ou nova janela",
+    "openModeNewWindow": "Nova janela",
+    "openModeNewTab": "Nova aba",
+    "urls": "URLs",
+    "urlPlaceholder": "https://…",
+    "addUrl": "Adicionar URL",
+    "removeUrl": "Remover URL",
+    "save": "Salvar",
+    "saving": "Salvando…",
+    "cancel": "Cancelar",
+    "delete": "Excluir",
+    "confirmDelete": "Excluir aba \"{{label}}\"? Essa ação não pode ser desfeita.",
+    "validationNameOrIcon": "Preencha nome ou ícone.",
+    "validationAtLeastOneUrl": "Adicione ao menos uma URL.",
+    "validationInvalidUrl": "URL inválida: {{value}}"
+  }
+}
+```
+
+E completar a seção `errors.config` com a chave que o `save_atomic` pode produzir (não há nova — as de `validate` já cobrem; mas adicionar `ioGeneric` fallback se ainda não existir — já existe do Plano 2).
+
+Em `src/locales/en.json`, espelhar:
+
+```json
+"settings": {
+  "title": "Settings",
+  "tabs": {
+    "sectionTitle": "Tabs",
+    "addTab": "Add tab",
+    "empty": "No tabs yet. Click \"Add tab\" to begin.",
+    "selectPrompt": "Select a tab to edit, or click \"Add tab\"."
+  },
+  "editor": {
+    "newTabTitle": "New tab",
+    "name": "Name",
+    "namePlaceholder": "Work",
+    "icon": "Icon",
+    "iconPlaceholder": "💼",
+    "iconHint": "An emoji or short character. Name or icon is required.",
+    "openMode": "Open mode",
+    "openModeReuseOrNewWindow": "Reuse or new window",
+    "openModeNewWindow": "New window",
+    "openModeNewTab": "New tab",
+    "urls": "URLs",
+    "urlPlaceholder": "https://…",
+    "addUrl": "Add URL",
+    "removeUrl": "Remove URL",
+    "save": "Save",
+    "saving": "Saving…",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "confirmDelete": "Delete tab \"{{label}}\"? This cannot be undone.",
+    "validationNameOrIcon": "Provide a name or an icon.",
+    "validationAtLeastOneUrl": "Add at least one URL.",
+    "validationInvalidUrl": "Invalid URL: {{value}}"
+  }
+}
+```
+
+- [ ] **Step 6.3 — Typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 6.4 — Commit**
+
+```bash
+git add src/core/ipc.ts src/locales/
+git commit -m "feat(ipc): typed wrappers for settings commands and locale keys"
+```
+
+---
+
+### Task 7: Hook `useConfig`
+
+**Arquivos:**
+- Criar: `src/settings/useConfig.ts`
+- Criar: `src/settings/__tests__/useConfig.test.tsx`
+
+Responsabilidade: única fonte de verdade do estado de `config` na janela Settings. Faz `getConfig()` no mount, escuta `config-changed` para reagir a mudanças vindas do próprio save (ou de um futuro fluxo externo), e expõe `saveTab`/`deleteTab` que atualizam otimisticamente + chamam IPC.
+
+- [ ] **Step 7.1 — Escrever testes (FALHAM)**
+
+```tsx
+// src/settings/__tests__/useConfig.test.tsx
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useConfig } from "../useConfig";
+
+type Listener = (e: { payload: unknown }) => void;
+
+vi.mock("@tauri-apps/api/event", () => {
+  const listeners = new Map<string, Set<Listener>>();
+  return {
+    listen: vi.fn(async (name: string, cb: Listener) => {
+      const set = listeners.get(name) ?? new Set<Listener>();
+      set.add(cb);
+      listeners.set(name, set);
+      return () => {
+        set.delete(cb);
+      };
+    }),
+    __emit: (name: string, payload: unknown) => {
+      listeners.get(name)?.forEach((cb) => cb({ payload }));
+    },
+  };
+});
+
+vi.mock("../../core/ipc", () => ({
+  ipc: {
+    getConfig: vi.fn(),
+    saveTab: vi.fn(),
+    deleteTab: vi.fn(),
+    openSettings: vi.fn(),
+    closeSettings: vi.fn(),
+    openTab: vi.fn(),
+    hideDonut: vi.fn(),
+  },
+  CONFIG_CHANGED_EVENT: "config-changed",
+}));
+
+import { ipc } from "../../core/ipc";
+import * as events from "@tauri-apps/api/event";
+
+const makeConfig = (overrides: Partial<{ tabs: unknown[] }> = {}) => ({
+  version: 1,
+  shortcut: "CommandOrControl+Shift+Space",
+  appearance: { theme: "dark", language: "auto" },
+  interaction: { spawnPosition: "cursor", selectionMode: "clickOrRelease", hoverHoldMs: 800 },
+  pagination: { itemsPerPage: 6, wheelDirection: "standard" },
+  system: { autostart: false },
+  tabs: [],
+  ...overrides,
+});
+
+describe("useConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads config on mount", async () => {
+    const cfg = makeConfig();
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(cfg);
+    const { result } = renderHook(() => useConfig());
+    await waitFor(() => expect(result.current.config).toEqual(cfg));
+  });
+
+  it("applies config-changed event updates", async () => {
+    const initial = makeConfig();
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(initial);
+    const { result } = renderHook(() => useConfig());
+    await waitFor(() => expect(result.current.config).toEqual(initial));
+
+    const updated = makeConfig({ tabs: [{ id: "x" } as unknown] });
+    act(() => {
+      (events as unknown as { __emit: (n: string, p: unknown) => void }).__emit(
+        "config-changed",
+        updated,
+      );
+    });
+    await waitFor(() => expect(result.current.config).toEqual(updated));
+  });
+
+  it("saveTab delegates to ipc and returns the new config", async () => {
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(makeConfig());
+    const updated = makeConfig({ tabs: [{ id: "n" } as unknown] });
+    (ipc.saveTab as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+
+    const { result } = renderHook(() => useConfig());
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+
+    const tab = { id: "n", name: "N", icon: null, order: 0, openMode: "newTab", items: [] } as never;
+    const returned = await act(() => result.current.saveTab(tab));
+    expect(returned).toEqual(updated);
+    expect(ipc.saveTab).toHaveBeenCalledWith(tab);
+  });
+
+  it("deleteTab delegates to ipc", async () => {
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(makeConfig());
+    const updated = makeConfig();
+    (ipc.deleteTab as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+
+    const { result } = renderHook(() => useConfig());
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+
+    await act(() => result.current.deleteTab("some-id"));
+    expect(ipc.deleteTab).toHaveBeenCalledWith("some-id");
+  });
+});
+```
+
+- [ ] **Step 7.2 — Implementar `useConfig`**
+
+```ts
+// src/settings/useConfig.ts
+import { useEffect, useState, useCallback } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { ipc, CONFIG_CHANGED_EVENT } from "../core/ipc";
+import type { Config } from "../core/types/Config";
+import type { Tab } from "../core/types/Tab";
+
+export interface UseConfig {
+  config: Config | null;
+  loadError: unknown;
+  saveTab: (tab: Tab) => Promise<Config>;
+  deleteTab: (tabId: string) => Promise<Config>;
+}
+
+export function useConfig(): UseConfig {
+  const [config, setConfig] = useState<Config | null>(null);
+  const [loadError, setLoadError] = useState<unknown>(null);
+
+  useEffect(() => {
+    let disposed = false;
+    ipc
+      .getConfig()
+      .then((c) => {
+        if (!disposed) setConfig(c);
+      })
+      .catch((e) => {
+        if (!disposed) setLoadError(e);
+      });
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    void listen<Config>(CONFIG_CHANGED_EVENT, (e) => {
+      setConfig(e.payload);
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  const saveTab = useCallback(async (tab: Tab) => {
+    const next = await ipc.saveTab(tab);
+    setConfig(next);
+    return next;
+  }, []);
+
+  const deleteTab = useCallback(async (tabId: string) => {
+    const next = await ipc.deleteTab(tabId);
+    setConfig(next);
+    return next;
+  }, []);
+
+  return { config, loadError, saveTab, deleteTab };
+}
+```
+
+- [ ] **Step 7.3 — Rodar testes**
+
+```bash
+npm test -- --run src/settings/__tests__/useConfig.test.tsx
+```
+
+- [ ] **Step 7.4 — Commit**
+
+```bash
+git add src/settings/useConfig.ts src/settings/__tests__/useConfig.test.tsx
+git commit -m "feat(settings): useConfig hook with config-changed subscription"
+```
+
+---
+
+### Task 8: `<TabList>`
+
+**Arquivos:**
+- Criar: `src/settings/TabList.tsx`
+- Criar: `src/settings/__tests__/TabList.test.tsx`
+
+- [ ] **Step 8.1 — Escrever testes (FALHAM)**
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { I18nextProvider } from "react-i18next";
+import { createI18n } from "../../core/i18n";
+import { TabList } from "../TabList";
+import type { Tab } from "../../core/types/Tab";
+
+async function renderWithI18n(ui: React.ReactElement) {
+  const i18n = await createI18n("pt-BR");
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>);
+}
+
+const tab = (id: string, name: string, order: number): Tab => ({
+  id,
+  name,
+  icon: null,
+  order,
+  openMode: "reuseOrNewWindow",
+  items: [],
+});
+
+describe("TabList", () => {
+  it("renders empty state when there are no tabs", async () => {
+    const onSelect = vi.fn();
+    const onAdd = vi.fn();
+    await renderWithI18n(<TabList tabs={[]} selectedId={null} onSelect={onSelect} onAdd={onAdd} />);
+    expect(screen.getByText(/nenhuma aba cadastrada/i)).toBeTruthy();
+  });
+
+  it("renders tabs sorted by order and highlights the selected one", async () => {
+    const t0 = tab("a", "A", 1);
+    const t1 = tab("b", "B", 0);
+    await renderWithI18n(
+      <TabList tabs={[t0, t1]} selectedId="a" onSelect={() => {}} onAdd={() => {}} />,
+    );
+    const items = screen.getAllByRole("button").filter((b) => b.getAttribute("data-testid") === "tab-row");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("B");
+    expect(items[1]).toHaveTextContent("A");
+    expect(items[1]).toHaveAttribute("data-selected", "true");
+  });
+
+  it("calls onSelect with the tab id on click", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    await renderWithI18n(
+      <TabList tabs={[tab("a", "A", 0)]} selectedId={null} onSelect={onSelect} onAdd={() => {}} />,
+    );
+    await user.click(screen.getByText("A"));
+    expect(onSelect).toHaveBeenCalledWith("a");
+  });
+
+  it("calls onAdd when clicking the add button", async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+    await renderWithI18n(
+      <TabList tabs={[]} selectedId={null} onSelect={() => {}} onAdd={onAdd} />,
+    );
+    await user.click(screen.getByRole("button", { name: /adicionar aba/i }));
+    expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 8.2 — Implementar `TabList.tsx`**
+
+```tsx
+import React from "react";
+import { useTranslation } from "react-i18next";
+import type { Tab } from "../core/types/Tab";
+
+export interface TabListProps {
+  tabs: Tab[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onAdd: () => void;
+}
+
+export const TabList: React.FC<TabListProps> = ({ tabs, selectedId, onSelect, onAdd }) => {
+  const { t } = useTranslation();
+  const ordered = [...tabs].sort((a, b) => a.order - b.order);
+
+  return (
+    <aside
+      style={{
+        width: 260,
+        borderRight: "1px solid #23304d",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        padding: 12,
+        background: "#0c1020",
+      }}
+    >
+      <header style={{ fontSize: 13, color: "#8ea", textTransform: "uppercase", letterSpacing: 0.5 }}>
+        {t("settings.tabs.sectionTitle")}
+      </header>
+      <button
+        type="button"
+        onClick={onAdd}
+        style={{
+          background: "#1d2a4a",
+          color: "#dde",
+          border: "1px solid #334",
+          borderRadius: 6,
+          padding: "8px 10px",
+          cursor: "pointer",
+          font: "inherit",
+          textAlign: "left",
+        }}
+      >
+        + {t("settings.tabs.addTab")}
+      </button>
+
+      {ordered.length === 0 ? (
+        <p style={{ color: "#889", fontSize: 13, lineHeight: 1.4 }}>
+          {t("settings.tabs.empty")}
+        </p>
+      ) : (
+        <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 4 }}>
+          {ordered.map((tab) => {
+            const selected = tab.id === selectedId;
+            const label = tab.name ?? tab.icon ?? tab.id.slice(0, 6);
+            return (
+              <li key={tab.id}>
+                <button
+                  type="button"
+                  data-testid="tab-row"
+                  data-selected={selected ? "true" : "false"}
+                  onClick={() => onSelect(tab.id)}
+                  style={{
+                    width: "100%",
+                    textAlign: "left",
+                    background: selected ? "#253e6b" : "transparent",
+                    color: "#dde",
+                    border: "1px solid " + (selected ? "#3e63a8" : "transparent"),
+                    borderRadius: 6,
+                    padding: "8px 10px",
+                    cursor: "pointer",
+                    font: "inherit",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                  }}
+                >
+                  <span style={{ width: 20, textAlign: "center" }}>{tab.icon ?? "•"}</span>
+                  <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {label}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </aside>
+  );
+};
+```
+
+- [ ] **Step 8.3 — Instalar `@testing-library/user-event` se ainda não tiver**
+
+```bash
+npm install -D @testing-library/user-event
+```
+
+- [ ] **Step 8.4 — Rodar tests**
+
+```bash
+npm test -- --run src/settings/__tests__/TabList.test.tsx
+```
+
+- [ ] **Step 8.5 — Commit**
+
+```bash
+git add src/settings/TabList.tsx src/settings/__tests__/TabList.test.tsx package.json package-lock.json
+git commit -m "feat(settings): TabList component"
+```
+
+---
+
+### Task 9: `<UrlListEditor>` + `<TabEditor>`
+
+**Arquivos:**
+- Criar: `src/settings/UrlListEditor.tsx`
+- Criar: `src/settings/TabEditor.tsx`
+- Criar: `src/settings/__tests__/TabEditor.test.tsx`
+
+- [ ] **Step 9.1 — Escrever testes (FALHAM)**
+
+Cobrem: validações client-side, submit chamando `onSave`, cancel, delete com confirm, exibição dos modos.
+
+```tsx
+// src/settings/__tests__/TabEditor.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { I18nextProvider } from "react-i18next";
+import { createI18n } from "../../core/i18n";
+import { TabEditor } from "../TabEditor";
+import type { Tab } from "../../core/types/Tab";
+
+async function renderEditor(props: Partial<Parameters<typeof TabEditor>[0]> = {}) {
+  const i18n = await createI18n("pt-BR");
+  const merged = {
+    mode: "new" as const,
+    initial: null,
+    onSave: vi.fn().mockResolvedValue(undefined),
+    onCancel: vi.fn(),
+    onDelete: vi.fn().mockResolvedValue(undefined),
+    ...props,
+  };
+  const utils = render(
+    <I18nextProvider i18n={i18n}>
+      <TabEditor {...merged} />
+    </I18nextProvider>,
+  );
+  return { ...utils, props: merged };
+}
+
+const existing: Tab = {
+  id: "11111111-1111-1111-1111-111111111111",
+  name: "Trabalho",
+  icon: "💼",
+  order: 0,
+  openMode: "reuseOrNewWindow",
+  items: [{ kind: "url", value: "https://example.com" }],
+};
+
+describe("TabEditor", () => {
+  it("requires name or icon", async () => {
+    const user = userEvent.setup();
+    const { props } = await renderEditor();
+    await user.type(screen.getByLabelText(/url/i), "https://ok.test");
+    await user.click(screen.getByRole("button", { name: /salvar/i }));
+    expect(screen.getByText(/preencha nome ou ícone/i)).toBeTruthy();
+    expect(props.onSave).not.toHaveBeenCalled();
+  });
+
+  it("requires at least one URL", async () => {
+    const user = userEvent.setup();
+    const { props } = await renderEditor();
+    await user.type(screen.getByLabelText(/nome/i), "A");
+    await user.click(screen.getByRole("button", { name: /remover url/i }));
+    await user.click(screen.getByRole("button", { name: /salvar/i }));
+    expect(screen.getByText(/adicione ao menos uma url/i)).toBeTruthy();
+    expect(props.onSave).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed URLs client-side", async () => {
+    const user = userEvent.setup();
+    const { props } = await renderEditor();
+    await user.type(screen.getByLabelText(/nome/i), "A");
+    await user.type(screen.getByLabelText(/url/i), "not a url");
+    await user.click(screen.getByRole("button", { name: /salvar/i }));
+    expect(screen.getByText(/url inválida/i)).toBeTruthy();
+    expect(props.onSave).not.toHaveBeenCalled();
+  });
+
+  it("saves a valid new tab with only-icon", async () => {
+    const user = userEvent.setup();
+    const { props } = await renderEditor();
+    await user.type(screen.getByLabelText(/ícone/i), "📝");
+    await user.type(screen.getByLabelText(/url/i), "https://a.test");
+    await user.click(screen.getByRole("button", { name: /salvar/i }));
+    expect(props.onSave).toHaveBeenCalledTimes(1);
+    const payload = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as Tab;
+    expect(payload.icon).toBe("📝");
+    expect(payload.name).toBeNull();
+    expect(payload.items).toHaveLength(1);
+  });
+
+  it("prefills fields when editing an existing tab", async () => {
+    await renderEditor({ mode: "edit", initial: existing });
+    expect((screen.getByLabelText(/nome/i) as HTMLInputElement).value).toBe("Trabalho");
+    expect((screen.getByLabelText(/ícone/i) as HTMLInputElement).value).toBe("💼");
+    const urlInputs = screen.getAllByLabelText(/url/i);
+    expect((urlInputs[0] as HTMLInputElement).value).toBe("https://example.com");
+  });
+
+  it("delete is only shown in edit mode and calls onDelete after confirm", async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    try {
+      const { props } = await renderEditor({ mode: "edit", initial: existing });
+      await user.click(screen.getByRole("button", { name: /excluir/i }));
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(props.onDelete).toHaveBeenCalledWith(existing.id);
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+});
+```
+
+- [ ] **Step 9.2 — Implementar `UrlListEditor.tsx`**
+
+```tsx
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+export interface UrlListEditorProps {
+  values: string[];
+  onChange: (next: string[]) => void;
+}
+
+export const UrlListEditor: React.FC<UrlListEditorProps> = ({ values, onChange }) => {
+  const { t } = useTranslation();
+
+  const update = (i: number, v: string) => {
+    const next = [...values];
+    next[i] = v;
+    onChange(next);
+  };
+
+  const remove = (i: number) => {
+    const next = values.filter((_, idx) => idx !== i);
+    onChange(next);
+  };
+
+  const add = () => onChange([...values, ""]);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      {values.map((v, i) => (
+        <div key={i} style={{ display: "flex", gap: 6 }}>
+          <input
+            aria-label={`URL ${i + 1}`}
+            value={v}
+            onChange={(e) => update(i, e.target.value)}
+            placeholder={t("settings.editor.urlPlaceholder")}
+            style={{
+              flex: 1,
+              background: "#12192c",
+              color: "#dde",
+              border: "1px solid #2a3557",
+              borderRadius: 4,
+              padding: "6px 8px",
+              font: "inherit",
+            }}
+          />
+          <button
+            type="button"
+            aria-label={t("settings.editor.removeUrl")}
+            onClick={() => remove(i)}
+            style={{
+              background: "transparent",
+              color: "#a77",
+              border: "1px solid #532",
+              borderRadius: 4,
+              padding: "4px 10px",
+              cursor: "pointer",
+            }}
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={add}
+        style={{
+          alignSelf: "flex-start",
+          background: "transparent",
+          color: "#8ea",
+          border: "1px dashed #355",
+          borderRadius: 4,
+          padding: "4px 10px",
+          cursor: "pointer",
+          fontSize: 12,
+        }}
+      >
+        + {t("settings.editor.addUrl")}
+      </button>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 9.3 — Implementar `TabEditor.tsx`**
+
+```tsx
+import React, { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { UrlListEditor } from "./UrlListEditor";
+import { translateAppError } from "../core/errors";
+import type { Tab } from "../core/types/Tab";
+import type { OpenMode } from "../core/types/OpenMode";
+
+type Mode = "new" | "edit";
+
+export interface TabEditorProps {
+  mode: Mode;
+  initial: Tab | null;
+  onSave: (tab: Tab) => Promise<void>;
+  onCancel: () => void;
+  onDelete: (tabId: string) => Promise<void>;
+}
+
+interface FormState {
+  id: string;
+  name: string;
+  icon: string;
+  openMode: OpenMode;
+  urls: string[];
+}
+
+const OPEN_MODES: OpenMode[] = ["reuseOrNewWindow", "newWindow", "newTab"];
+
+function randomUuid(): string {
+  // crypto.randomUUID está disponível em WebView modernas (Chromium/Webkit).
+  return crypto.randomUUID();
+}
+
+function fromTab(tab: Tab | null): FormState {
+  if (!tab) {
+    return { id: randomUuid(), name: "", icon: "", openMode: "reuseOrNewWindow", urls: [""] };
+  }
+  return {
+    id: tab.id,
+    name: tab.name ?? "",
+    icon: tab.icon ?? "",
+    openMode: tab.openMode,
+    urls: tab.items.length
+      ? tab.items.map((it) => (it.kind === "url" ? it.value : ""))
+      : [""],
+  };
+}
+
+export const TabEditor: React.FC<TabEditorProps> = ({ mode, initial, onSave, onCancel, onDelete }) => {
+  const { t } = useTranslation();
+  const [state, setState] = useState<FormState>(() => fromTab(initial));
+  const [validation, setValidation] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setState(fromTab(initial));
+    setValidation(null);
+    setServerError(null);
+  }, [initial, mode]);
+
+  const openModeLabels = useMemo<Record<OpenMode, string>>(
+    () => ({
+      reuseOrNewWindow: t("settings.editor.openModeReuseOrNewWindow"),
+      newWindow: t("settings.editor.openModeNewWindow"),
+      newTab: t("settings.editor.openModeNewTab"),
+    }),
+    [t],
+  );
+
+  const submit = async () => {
+    setServerError(null);
+
+    const name = state.name.trim();
+    const icon = state.icon.trim();
+    if (!name && !icon) {
+      setValidation(t("settings.editor.validationNameOrIcon"));
+      return;
+    }
+
+    const urls = state.urls.map((u) => u.trim()).filter((u) => u.length > 0);
+    if (urls.length === 0) {
+      setValidation(t("settings.editor.validationAtLeastOneUrl"));
+      return;
+    }
+
+    for (const u of urls) {
+      try {
+        new URL(u);
+      } catch {
+        setValidation(t("settings.editor.validationInvalidUrl", { value: u }));
+        return;
+      }
+    }
+
+    setValidation(null);
+
+    const payload: Tab = {
+      id: state.id,
+      name: name.length > 0 ? name : null,
+      icon: icon.length > 0 ? icon : null,
+      order: initial?.order ?? 0, // o Rust normaliza
+      openMode: state.openMode,
+      items: urls.map((value) => ({ kind: "url", value })),
+    };
+
+    setSaving(true);
+    try {
+      await onSave(payload);
+    } catch (err) {
+      setServerError(translateAppError(err, t));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const requestDelete = async () => {
+    if (!initial) return;
+    const label = initial.name ?? initial.icon ?? initial.id.slice(0, 6);
+    const confirmed = window.confirm(t("settings.editor.confirmDelete", { label }));
+    if (!confirmed) return;
+    try {
+      await onDelete(initial.id);
+    } catch (err) {
+      setServerError(translateAppError(err, t));
+    }
+  };
+
+  const title = mode === "new" ? t("settings.editor.newTabTitle") : state.name || state.icon || "";
+
+  const inputStyle: React.CSSProperties = {
+    background: "#12192c",
+    color: "#dde",
+    border: "1px solid #2a3557",
+    borderRadius: 4,
+    padding: "6px 8px",
+    font: "inherit",
+  };
+
+  return (
+    <section
+      style={{
+        flex: 1,
+        padding: 24,
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+        overflow: "auto",
+      }}
+    >
+      <h2 style={{ margin: 0 }}>{title}</h2>
+
+      <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <span>{t("settings.editor.name")}</span>
+        <input
+          value={state.name}
+          onChange={(e) => setState({ ...state, name: e.target.value })}
+          placeholder={t("settings.editor.namePlaceholder")}
+          style={inputStyle}
+        />
+      </label>
+
+      <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <span>{t("settings.editor.icon")}</span>
+        <input
+          value={state.icon}
+          onChange={(e) => setState({ ...state, icon: e.target.value })}
+          placeholder={t("settings.editor.iconPlaceholder")}
+          style={{ ...inputStyle, width: 120 }}
+        />
+        <small style={{ color: "#889" }}>{t("settings.editor.iconHint")}</small>
+      </label>
+
+      <fieldset style={{ border: "1px solid #2a3557", borderRadius: 4, padding: 12 }}>
+        <legend style={{ padding: "0 6px" }}>{t("settings.editor.openMode")}</legend>
+        {OPEN_MODES.map((m) => (
+          <label key={m} style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}>
+            <input
+              type="radio"
+              name="openMode"
+              checked={state.openMode === m}
+              onChange={() => setState({ ...state, openMode: m })}
+            />
+            {openModeLabels[m]}
+          </label>
+        ))}
+      </fieldset>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <span>{t("settings.editor.urls")}</span>
+        <UrlListEditor
+          values={state.urls}
+          onChange={(urls) => setState({ ...state, urls })}
+        />
+      </div>
+
+      {validation && (
+        <div role="alert" style={{ color: "#f99" }}>
+          {validation}
+        </div>
+      )}
+      {serverError && (
+        <div role="alert" style={{ color: "#f99" }}>
+          {serverError}
+        </div>
+      )}
+
+      <footer style={{ display: "flex", gap: 8, marginTop: "auto" }}>
+        <button
+          type="button"
+          disabled={saving}
+          onClick={submit}
+          style={{
+            background: "#2a4a7d",
+            color: "#fff",
+            border: 0,
+            borderRadius: 4,
+            padding: "8px 16px",
+            cursor: saving ? "wait" : "pointer",
+          }}
+        >
+          {saving ? t("settings.editor.saving") : t("settings.editor.save")}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          style={{
+            background: "transparent",
+            color: "#dde",
+            border: "1px solid #334",
+            borderRadius: 4,
+            padding: "8px 16px",
+            cursor: "pointer",
+          }}
+        >
+          {t("settings.editor.cancel")}
+        </button>
+        {mode === "edit" && initial && (
+          <button
+            type="button"
+            onClick={requestDelete}
+            style={{
+              marginLeft: "auto",
+              background: "transparent",
+              color: "#f99",
+              border: "1px solid #532",
+              borderRadius: 4,
+              padding: "8px 16px",
+              cursor: "pointer",
+            }}
+          >
+            {t("settings.editor.delete")}
+          </button>
+        )}
+      </footer>
+    </section>
+  );
+};
+```
+
+- [ ] **Step 9.4 — Rodar testes**
+
+```bash
+npm test -- --run src/settings/__tests__/TabEditor.test.tsx
+```
+
+- [ ] **Step 9.5 — Commit**
+
+```bash
+git add src/settings/TabEditor.tsx src/settings/UrlListEditor.tsx src/settings/__tests__/TabEditor.test.tsx
+git commit -m "feat(settings): TabEditor with client-side validation and URL list"
+```
+
+---
+
+### Task 10: `<SettingsApp>` e `src/entry/settings.tsx`
+
+**Arquivos:**
+- Criar: `src/settings/SettingsApp.tsx`
+- Modificar: `src/entry/settings.tsx`
+
+- [ ] **Step 10.1 — Criar `SettingsApp.tsx`**
+
+```tsx
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { TabList } from "./TabList";
+import { TabEditor } from "./TabEditor";
+import { useConfig } from "./useConfig";
+import type { Tab } from "../core/types/Tab";
+
+type Selection =
+  | { mode: "empty" }
+  | { mode: "new" }
+  | { mode: "edit"; tabId: string };
+
+export const SettingsApp: React.FC = () => {
+  const { t } = useTranslation();
+  const { config, saveTab, deleteTab } = useConfig();
+  const [selection, setSelection] = useState<Selection>({ mode: "empty" });
+
+  if (!config) {
+    return <div style={{ padding: 24 }}>…</div>;
+  }
+
+  const selectedTab: Tab | null =
+    selection.mode === "edit"
+      ? config.tabs.find((t) => t.id === selection.tabId) ?? null
+      : null;
+
+  const handleSave = async (tab: Tab) => {
+    await saveTab(tab);
+    setSelection({ mode: "edit", tabId: tab.id });
+  };
+
+  const handleDelete = async (tabId: string) => {
+    await deleteTab(tabId);
+    setSelection({ mode: "empty" });
+  };
+
+  return (
+    <div style={{ display: "flex", height: "100vh" }}>
+      <TabList
+        tabs={config.tabs}
+        selectedId={selection.mode === "edit" ? selection.tabId : null}
+        onSelect={(id) => setSelection({ mode: "edit", tabId: id })}
+        onAdd={() => setSelection({ mode: "new" })}
+      />
+      {selection.mode === "new" ? (
+        <TabEditor
+          mode="new"
+          initial={null}
+          onSave={handleSave}
+          onCancel={() => setSelection({ mode: "empty" })}
+          onDelete={handleDelete}
+        />
+      ) : selection.mode === "edit" && selectedTab ? (
+        <TabEditor
+          mode="edit"
+          initial={selectedTab}
+          onSave={handleSave}
+          onCancel={() => setSelection({ mode: "empty" })}
+          onDelete={handleDelete}
+        />
+      ) : (
+        <section
+          style={{
+            flex: 1,
+            display: "grid",
+            placeItems: "center",
+            color: "#889",
+            padding: 24,
+            textAlign: "center",
+          }}
+        >
+          {t("settings.tabs.selectPrompt")}
+        </section>
+      )}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 10.2 — Substituir `src/entry/settings.tsx`**
+
+```tsx
+import { createRoot } from "react-dom/client";
+import { I18nextProvider } from "react-i18next";
+import i18next from "i18next";
+import { ipc } from "../core/ipc";
+import { initI18n } from "../core/i18n";
+import { SettingsApp } from "../settings/SettingsApp";
+import type { Config } from "../core/types/Config";
+
+async function bootstrap() {
+  let language: Config["appearance"]["language"] = "auto";
+  try {
+    const cfg = await ipc.getConfig();
+    language = cfg.appearance.language;
+  } catch (e) {
+    console.error("getConfig failed during settings bootstrap; using auto", e);
+  }
+  await initI18n(language);
+
+  document.title = i18next.t("settings.title");
+
+  createRoot(document.getElementById("root")!).render(
+    <I18nextProvider i18n={i18next}>
+      <SettingsApp />
+    </I18nextProvider>,
+  );
+}
+
+void bootstrap();
+```
+
+- [ ] **Step 10.3 — Typecheck + testes frontend**
+
+```bash
+npx tsc --noEmit
+npm test -- --run
+```
+
+- [ ] **Step 10.4 — Smoke manual**
+
+```bash
+npm run tauri dev
+```
+
+Fluxo: tray → "Configurações" → janela aparece. Clicar em "Adicionar aba" → preencher nome e URL → "Salvar". A aba aparece na lista. Selecionar aba → "Excluir" → confirma → some. Editar URL mal formada → toast de erro client-side.
+
+- [ ] **Step 10.5 — Commit**
+
+```bash
+git add src/settings/SettingsApp.tsx src/entry/settings.tsx
+git commit -m "feat(settings): SettingsApp layout and bootstrap entrypoint"
+```
+
+---
+
+### Task 11: Donut escuta `config-changed`; engrenagem abre Settings
+
+**Arquivos:**
+- Modificar: `src/entry/donut.tsx`
+- Modificar: `src/donut/CenterCircle.tsx`
+- Modificar: `src/donut/Donut.tsx` (pass-through de `onOpenSettings` para o centro)
+
+- [ ] **Step 11.1 — `CenterCircle` fica clicável na metade da engrenagem**
+
+Adicionar prop `onGearClick?: () => void`. Renderizar um `<rect>` invisível sobre a metade esquerda do círculo central para capturar cliques:
+
+```tsx
+import React from "react";
+
+export interface CenterCircleProps {
+  cx: number;
+  cy: number;
+  r: number;
+  onGearClick?: () => void;
+}
+
+export const CenterCircle: React.FC<CenterCircleProps> = ({ cx, cy, r, onGearClick }) => (
+  <g>
+    <circle cx={cx} cy={cy} r={r} fill="#141a28" stroke="#3a4968" strokeWidth={1} />
+    <line x1={cx} y1={cy - r} x2={cx} y2={cy + r} stroke="#3a4968" strokeWidth={1} />
+    <text
+      x={cx - r / 2}
+      y={cy}
+      textAnchor="middle"
+      dominantBaseline="middle"
+      fontSize={28}
+      fill="#777"
+      style={{ userSelect: "none", pointerEvents: "none" }}
+    >
+      ⚙
+    </text>
+    <g
+      transform={`translate(${cx + r / 2}, ${cy - 3})`}
+      stroke="#777"
+      strokeWidth={1.8}
+      fill="none"
+      strokeLinecap="round"
+      pointerEvents="none"
+    >
+      <circle cx={0} cy={-6} r={5} />
+      <path d="M -9 12 A 10 10 0 0 1 9 12" />
+    </g>
+    {onGearClick && (
+      <rect
+        x={cx - r}
+        y={cy - r}
+        width={r}
+        height={r * 2}
+        fill="transparent"
+        style={{ cursor: "pointer" }}
+        onClick={(e) => {
+          e.stopPropagation();
+          onGearClick();
+        }}
+      />
+    )}
+  </g>
+);
+```
+
+Ajustar `Donut.tsx` para aceitar e repassar `onOpenSettings`:
+
+```tsx
+export interface DonutProps {
+  tabs: Tab[];
+  size: number;
+  onSelect: (tabId: string) => void;
+  onOpenSettings?: () => void;
+}
+
+// ...
+
+<CenterCircle cx={cx} cy={cy} r={innerR * 0.85} onGearClick={onOpenSettings} />
+```
+
+- [ ] **Step 11.2 — Atualizar o teste `Donut.test.tsx`**
+
+Acrescentar um caso que clica no rect da engrenagem e verifica `onOpenSettings`:
+
+```tsx
+it("chamas onOpenSettings ao clicar na metade esquerda do centro", async () => {
+  const onOpenSettings = vi.fn();
+  const { container } = render(
+    <Donut tabs={[]} size={300} onSelect={() => {}} onOpenSettings={onOpenSettings} />,
+  );
+  const gearHit = container.querySelector("rect[style*=\"cursor: pointer\"]") as SVGRectElement;
+  expect(gearHit).toBeTruthy();
+  fireEvent.click(gearHit);
+  expect(onOpenSettings).toHaveBeenCalledTimes(1);
+});
+```
+
+(Adaptar imports ao estilo existente do arquivo.)
+
+- [ ] **Step 11.3 — Donut escuta `config-changed` e usa `onOpenSettings`**
+
+Em `src/entry/donut.tsx`, dentro do `App`:
+
+```tsx
+import { listen } from "@tauri-apps/api/event";
+import { CONFIG_CHANGED_EVENT } from "../core/ipc";
+
+// ...
+
+useEffect(() => {
+  let unlisten: (() => void) | undefined;
+  void listen<Config>(CONFIG_CHANGED_EVENT, (e) => {
+    setConfig(e.payload);
+  }).then((fn) => {
+    unlisten = fn;
+  });
+  return () => { unlisten?.(); };
+}, []);
+
+const handleOpenSettings = async () => {
+  try {
+    await ipc.openSettings();
+  } finally {
+    void ipc.hideDonut();
+  }
+};
+
+// e passar ao <Donut>:
+<Donut
+  tabs={config.tabs}
+  size={WINDOW_SIZE}
+  onSelect={handleSelect}
+  onOpenSettings={handleOpenSettings}
+/>
+```
+
+- [ ] **Step 11.4 — Rodar testes completos**
+
+```bash
+npm test -- --run
+npx tsc --noEmit
+```
+
+- [ ] **Step 11.5 — Smoke**
+
+Com `npm run tauri dev` rodando: atalho → donut aparece → clicar na engrenagem → donut some, Settings aparece. Com ambas as janelas abertas, criar uma aba na Settings → donut refresca (a nova aba aparece ao reabrir o donut).
+
+- [ ] **Step 11.6 — Commit**
+
+```bash
+git add src/donut/CenterCircle.tsx src/donut/Donut.tsx src/donut/__tests__/Donut.test.tsx src/entry/donut.tsx
+git commit -m "feat(donut): gear opens settings; donut listens to config-changed"
+```
+
+---
+
+### Task 12: CI final + `CLAUDE.md` + PR
+
+**Arquivos:**
+- Modificar: `CLAUDE.md`
+
+- [ ] **Step 12.1 — Pipeline local completo**
+
+```bash
+npm test -- --run
+npx tsc --noEmit
+cd src-tauri && cargo fmt --check && cargo clippy --lib && cargo test --lib && cd ..
+```
+
+- [ ] **Step 12.2 — Atualizar `CLAUDE.md`**
+
+- Incluir `docs/plans/03-settings-crud.md` em "Start here".
+- Na seção "Big-picture architecture", trocar "Settings webview (not yet implemented — Plano 3)" por "Settings webview (implemented in Plano 3) — decorated window with TabList + TabEditor. Listens to `config-changed` from Rust; donut mirrors the same event."
+- Nas "Rust module responsibilities", descrever `settings_window/` e os novos comandos.
+- Na seção "Conventions", notar: "Mutações de `Config` passam por `save_tab`/`delete_tab`. Nenhum comando escreve disco diretamente — todos chamam `config::io::save_atomic`. Um `save_atomic` com sucesso deve ser seguido por `app.emit(CONFIG_CHANGED_EVENT, &config)`."
+- Em "Looking ahead", substituir o bloco por "Plano 4 (próximo)": ShortcutRecorder, AppearanceSection, `set_shortcut`, seletor de idioma consumindo `changeLanguage` (já pronto em `src/core/i18n.ts`). Mencionar que `AppState::config_path` agora é usado (remover bullet de `#[allow(dead_code)]`).
+
+- [ ] **Step 12.3 — Commit final + PR**
+
+```bash
+git add CLAUDE.md docs/plans/03-settings-crud.md
+git commit -m "docs(claude): mark Plano 3 (settings CRUD) complete"
+git push -u origin HEAD
+gh pr create --title "Plano 3 — Settings: CRUD de abas" --body "$(cat <<'EOF'
+## Summary
+- Nova janela Settings (decorada, multi-entry Vite) com TabList + TabEditor + UrlListEditor.
+- Rust: comandos `save_tab`/`delete_tab`/`open_settings`/`close_settings`, write atômica via `save_atomic` (`config.json.tmp` → rename) e evento `config-changed` emitido a cada mutação.
+- Tray ganha "Configurações"; engrenagem ⚙ do donut agora abre Settings.
+- Donut escuta `config-changed` e atualiza abas em tempo real.
+
+## Test plan
+- [ ] `cargo test --lib` passa (inclui `save_atomic` + `apply_save`/`apply_delete`).
+- [ ] `npm test` passa (TabList, TabEditor, UrlListEditor, useConfig, Donut).
+- [ ] `npx tsc --noEmit` / `cargo fmt --check` / `cargo clippy --lib` limpos.
+- [ ] Smoke: tray → Configurações → criar aba → salvar → aparece no donut sem reiniciar.
+- [ ] Smoke: excluir aba com confirmação → some de ambas as janelas.
+- [ ] Smoke: URL inválida client-side → mensagem em português/inglês conforme idioma.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Resumo dos commits previstos
+
+1. `chore(settings): add settings.html entry and vite multi-input`
+2. `feat(settings-window): module + capabilities for the settings webview`
+3. `feat(config): save_atomic writes to .tmp then renames`
+4. `feat(commands): save_tab/delete_tab with atomic write and config-changed event`
+5. `feat(tray): add Configurações menu item`
+6. `feat(ipc): typed wrappers for settings commands and locale keys`
+7. `feat(settings): useConfig hook with config-changed subscription`
+8. `feat(settings): TabList component`
+9. `feat(settings): TabEditor with client-side validation and URL list`
+10. `feat(settings): SettingsApp layout and bootstrap entrypoint`
+11. `feat(donut): gear opens settings; donut listens to config-changed`
+12. `docs(claude): mark Plano 3 (settings CRUD) complete`
+
+---
+
+## Critérios de aceitação
+
+- [ ] Abrir pelo tray ou pelo donut (clicando na engrenagem) leva à janela Settings.
+- [ ] Criar aba salva no `config.json` (verificar manualmente no `%APPDATA%` / `~/Library/...` / `~/.config/DonutTabs`). O arquivo nunca fica meio-escrito — ou salva completo, ou falha sem tocar no original.
+- [ ] Editar aba persiste; abrir o donut mostra a versão nova sem precisar reiniciar.
+- [ ] Excluir aba pede confirmação e só atua em caso de confirmação.
+- [ ] `config-changed` só é emitido em operações bem-sucedidas (se validação ou IO falhar, memória e disco permanecem coerentes).
+- [ ] Erros do Rust aparecem traduzidos na janela Settings via `translateAppError`.
+- [ ] `AppState::config_path` deixa de ter `#[allow(dead_code)]`.
+- [ ] CI verde em Linux/macOS/Windows.
+
+---
+
+## Notas para quem for implementar
+
+- **Ordem importa para a atomicidade.** `save_atomic` precisa validar **antes** de abrir o `.tmp`; do contrário, um `.tmp` órfão fica no diretório. O teste `save_atomic_rejects_invalid_config` cobre.
+- **Reordenar em delete, preservar em update.** Após `apply_delete`, renormalize `order` sequencialmente. Em `apply_save` existente, preserve o `order` antigo — o cliente não decide posição aqui (isso vem no Plano 7 com drag-and-drop).
+- **Evento `config-changed` sempre recebe o `Config` inteiro.** Evita race conditions e mantém o frontend simples. Se o payload crescer muito no futuro, aí sim passar a mandar diff — não otimize antecipadamente.
+- **`document.title` via i18n.** Setar no bootstrap depois de `initI18n()`, antes do primeiro render. Se em algum momento o Plano 4 trocar idioma em runtime, lembrar de reexecutar `document.title = i18next.t(...)` no callback de `changeLanguage`.
+- **Nada de `navigator.language` no Settings bootstrap.** A resolução de idioma já acontece dentro de `initI18n` via `resolveLanguage`. O bootstrap do settings é cópia do donut.tsx exatamente por isso — não duplicar lógica.
+- **Não adicionar `set_shortcut` ou preferências aqui.** Resistir ao impulso de "já que tô aqui, adiciono o seletor de tema" — isso é Plano 4 e tem validação de conflito de atalho própria.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@tauri-apps/cli": "^2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -1733,6 +1734,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tauri-apps/cli": "^2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DonutTabs — Configurações</title>
+    <style>
+      html, body { margin: 0; padding: 0; height: 100%; background: #0f1320; color: #dde; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+      #root { width: 100vw; height: 100vh; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/entry/settings.tsx"></script>
+  </body>
+</html>

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,13 +2,14 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capabilities padrão do DonutTabs",
-  "windows": ["donut"],
+  "windows": ["donut", "settings"],
   "permissions": [
     "core:default",
     "core:window:allow-close",
     "core:window:allow-hide",
     "core:window:allow-show",
     "core:window:allow-set-focus",
+    "core:event:default",
     "global-shortcut:default",
     "opener:default",
     "opener:allow-open-url"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,16 +1,16 @@
-use crate::config::{io::load_from_path, schema::Config};
+use crate::config::io::{load_from_path, save_atomic};
+use crate::config::schema::{Config, Tab};
 use crate::errors::{AppError, AppResult};
 use crate::launcher::{launch_tab, TauriOpener};
 use std::path::PathBuf;
 use std::sync::RwLock;
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 use uuid::Uuid;
+
+pub const CONFIG_CHANGED_EVENT: &str = "config-changed";
 
 pub struct AppState {
     pub config: RwLock<Config>,
-    /// Caminho para o arquivo de config em disco. Reservado para o Plano 2,
-    /// quando `save_tab`/`delete_tab` farão write atômica de volta ao disco.
-    #[allow(dead_code)]
     pub config_path: PathBuf,
 }
 
@@ -46,10 +46,169 @@ pub fn hide_donut<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), App
     Ok(())
 }
 
+#[tauri::command]
+pub fn save_tab<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    tab: Tab,
+) -> Result<Config, AppError> {
+    let snapshot = {
+        let mut cfg = state.config.write().unwrap();
+        apply_save(&mut cfg, tab);
+        if let Err(e) = save_atomic(&state.config_path, &cfg) {
+            // Recarrega do disco para que a memória reflita o último estado bom.
+            if let Ok(fresh) = load_from_path(&state.config_path) {
+                *cfg = fresh;
+            }
+            return Err(e);
+        }
+        cfg.clone()
+    };
+
+    let _ = app.emit(CONFIG_CHANGED_EVENT, &snapshot);
+    Ok(snapshot)
+}
+
+#[tauri::command]
+pub fn delete_tab<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    tab_id: Uuid,
+) -> Result<Config, AppError> {
+    let snapshot = {
+        let mut cfg = state.config.write().unwrap();
+        apply_delete(&mut cfg, tab_id);
+        if let Err(e) = save_atomic(&state.config_path, &cfg) {
+            if let Ok(fresh) = load_from_path(&state.config_path) {
+                *cfg = fresh;
+            }
+            return Err(e);
+        }
+        cfg.clone()
+    };
+
+    let _ = app.emit(CONFIG_CHANGED_EVENT, &snapshot);
+    Ok(snapshot)
+}
+
+#[tauri::command]
+pub fn open_settings<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), AppError> {
+    crate::settings_window::show(&app)
+}
+
+#[tauri::command]
+pub fn close_settings<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), AppError> {
+    crate::settings_window::close(&app)
+}
+
 pub fn initial_load(config_path: PathBuf) -> AppResult<AppState> {
     let cfg = load_from_path(&config_path)?;
     Ok(AppState {
         config: RwLock::new(cfg),
         config_path,
     })
+}
+
+fn apply_save(cfg: &mut Config, incoming: Tab) {
+    if let Some(existing) = cfg.tabs.iter_mut().find(|t| t.id == incoming.id) {
+        let order = existing.order;
+        *existing = Tab { order, ..incoming };
+    } else {
+        let order = cfg.tabs.len() as u32;
+        cfg.tabs.push(Tab { order, ..incoming });
+    }
+}
+
+fn apply_delete(cfg: &mut Config, id: Uuid) {
+    cfg.tabs.retain(|t| t.id != id);
+    for (i, t) in cfg.tabs.iter_mut().enumerate() {
+        t.order = i as u32;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::schema::{Item, OpenMode, Tab};
+    use uuid::Uuid;
+
+    fn sample_tab(name: &str) -> Tab {
+        Tab {
+            id: Uuid::new_v4(),
+            name: Some(name.into()),
+            icon: None,
+            order: 0,
+            open_mode: OpenMode::ReuseOrNewWindow,
+            items: vec![Item::Url {
+                value: "https://example.com".into(),
+            }],
+        }
+    }
+
+    #[test]
+    fn apply_save_appends_new_tab_with_next_order() {
+        let mut cfg = Config::default();
+        let mut t0 = sample_tab("A");
+        t0.order = 0;
+        cfg.tabs.push(t0);
+
+        let new_tab = sample_tab("B");
+        let new_id = new_tab.id;
+        apply_save(&mut cfg, new_tab);
+
+        assert_eq!(cfg.tabs.len(), 2);
+        assert_eq!(cfg.tabs[1].id, new_id);
+        assert_eq!(cfg.tabs[1].order, 1);
+    }
+
+    #[test]
+    fn apply_save_updates_existing_tab_preserving_order() {
+        let mut cfg = Config::default();
+        let mut t = sample_tab("A");
+        t.order = 3;
+        let id = t.id;
+        cfg.tabs.push(t);
+
+        let mut updated = sample_tab("A-renamed");
+        updated.id = id;
+        updated.order = 99; // deve ser ignorado
+        apply_save(&mut cfg, updated);
+
+        assert_eq!(cfg.tabs.len(), 1);
+        assert_eq!(cfg.tabs[0].name.as_deref(), Some("A-renamed"));
+        assert_eq!(cfg.tabs[0].order, 3);
+    }
+
+    #[test]
+    fn apply_delete_removes_and_renormalizes_order() {
+        let mut cfg = Config::default();
+        let mut t0 = sample_tab("A");
+        t0.order = 0;
+        let mut t1 = sample_tab("B");
+        t1.order = 1;
+        let mut t2 = sample_tab("C");
+        t2.order = 2;
+        let id1 = t1.id;
+        cfg.tabs.push(t0);
+        cfg.tabs.push(t1);
+        cfg.tabs.push(t2);
+
+        apply_delete(&mut cfg, id1);
+
+        assert_eq!(cfg.tabs.len(), 2);
+        assert_eq!(cfg.tabs[0].order, 0);
+        assert_eq!(cfg.tabs[1].order, 1);
+        assert!(cfg.tabs.iter().all(|t| t.id != id1));
+    }
+
+    #[test]
+    fn apply_delete_on_missing_id_is_noop() {
+        let mut cfg = Config::default();
+        cfg.tabs.push(sample_tab("A"));
+        let before = cfg.tabs.len();
+
+        apply_delete(&mut cfg, Uuid::new_v4());
+
+        assert_eq!(cfg.tabs.len(), before);
+    }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,15 +3,21 @@ use crate::config::schema::{Config, Tab};
 use crate::errors::{AppError, AppResult};
 use crate::launcher::{launch_tab, TauriOpener};
 use std::path::PathBuf;
-use std::sync::RwLock;
+use std::sync::{Mutex, RwLock};
 use tauri::{Emitter, Manager};
 use uuid::Uuid;
 
 pub const CONFIG_CHANGED_EVENT: &str = "config-changed";
+pub const SETTINGS_INTENT_EVENT: &str = "settings-intent";
 
 pub struct AppState {
     pub config: RwLock<Config>,
     pub config_path: PathBuf,
+    /// Intent a ser consumido pela Settings na próxima montagem. Serve de
+    /// buffer para o caso em que a Settings ainda está carregando quando o
+    /// comando `open_settings` é invocado (evento de listen ainda não
+    /// registrado).
+    pub pending_settings_intent: Mutex<Option<String>>,
 }
 
 #[tauri::command]
@@ -92,8 +98,31 @@ pub fn delete_tab<R: tauri::Runtime>(
 }
 
 #[tauri::command]
-pub fn open_settings<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), AppError> {
-    crate::settings_window::show(&app)
+pub fn open_settings<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    intent: Option<String>,
+) -> Result<(), AppError> {
+    if let Some(intent) = &intent {
+        *state.pending_settings_intent.lock().unwrap() = Some(intent.clone());
+    }
+    crate::settings_window::show(&app)?;
+    if let Some(intent) = intent {
+        // Emite para quem já está escutando (janela reaberta). O
+        // `consume_settings_intent` abaixo cobre o caso em que a Settings
+        // ainda não tinha listener no momento do emit.
+        let _ = app.emit_to(
+            crate::settings_window::SETTINGS_LABEL,
+            SETTINGS_INTENT_EVENT,
+            intent,
+        );
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn consume_settings_intent(state: tauri::State<'_, AppState>) -> Option<String> {
+    state.pending_settings_intent.lock().unwrap().take()
 }
 
 #[tauri::command]
@@ -106,6 +135,7 @@ pub fn initial_load(config_path: PathBuf) -> AppResult<AppState> {
     Ok(AppState {
         config: RwLock::new(cfg),
         config_path,
+        pending_settings_intent: Mutex::new(None),
     })
 }
 

--- a/src-tauri/src/config/io.rs
+++ b/src-tauri/src/config/io.rs
@@ -1,6 +1,7 @@
 use super::schema::Config;
 use super::validate::validate;
 use crate::errors::AppResult;
+use std::io::Write;
 use std::path::Path;
 
 /// Lê a config do caminho dado. Se o arquivo não existe, retorna `Config::default()`.
@@ -13,6 +14,29 @@ pub fn load_from_path(path: &Path) -> AppResult<Config> {
     let config: Config = serde_json::from_str(&raw)?;
     validate(&config)?;
     Ok(config)
+}
+
+/// Grava a config em disco de forma atômica: valida, escreve em `<path>.tmp`,
+/// renomeia para `<path>`. Falhar antes do rename deixa o arquivo original intacto.
+pub fn save_atomic(path: &Path, config: &Config) -> AppResult<()> {
+    validate(config)?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let tmp_path = path.with_extension("json.tmp");
+    let json = serde_json::to_string_pretty(config)?;
+
+    {
+        let mut file = std::fs::File::create(&tmp_path)?;
+        file.write_all(json.as_bytes())?;
+        // best-effort fsync; Windows não garante fsync de diretório
+        let _ = file.sync_all();
+    }
+
+    std::fs::rename(&tmp_path, path)?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -57,6 +81,72 @@ mod tests {
         std::fs::write(&path, serde_json::to_string(&cfg).unwrap()).unwrap();
         let err = load_from_path(&path).unwrap_err();
         assert!(matches!(err, AppError::Config { .. }), "got: {err:?}");
+    }
+
+    #[test]
+    fn save_atomic_writes_then_renames() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let cfg = Config::default();
+
+        save_atomic(&path, &cfg).unwrap();
+
+        assert!(path.exists());
+        assert!(!path.with_extension("json.tmp").exists());
+
+        let loaded = load_from_path(&path).unwrap();
+        assert_eq!(loaded, cfg);
+    }
+
+    #[test]
+    fn save_atomic_overwrites_existing_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let cfg1 = Config::default();
+        save_atomic(&path, &cfg1).unwrap();
+
+        let mut cfg2 = cfg1.clone();
+        cfg2.pagination.items_per_page = 7;
+        save_atomic(&path, &cfg2).unwrap();
+
+        let loaded = load_from_path(&path).unwrap();
+        assert_eq!(loaded.pagination.items_per_page, 7);
+    }
+
+    #[test]
+    fn save_atomic_creates_parent_dir_if_missing() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nested").join("sub").join("config.json");
+        let cfg = Config::default();
+        save_atomic(&path, &cfg).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn save_atomic_rejects_invalid_config() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let mut cfg = Config::default();
+        cfg.pagination.items_per_page = 99;
+        let err = save_atomic(&path, &cfg).unwrap_err();
+        assert!(matches!(err, AppError::Config { .. }));
+        // Arquivo não foi criado — falhou antes de abrir o .tmp.
+        assert!(!path.exists());
+        assert!(!path.with_extension("json.tmp").exists());
+    }
+
+    #[test]
+    fn save_atomic_preserves_previous_file_on_identical_save() {
+        // Sanidade do contrato: uma segunda gravação idêntica resulta em conteúdo igual.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        let cfg = Config::default();
+        save_atomic(&path, &cfg).unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        save_atomic(&path, &cfg).unwrap();
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(before, after);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod config;
 mod donut_window;
 mod errors;
 mod launcher;
+mod settings_window;
 mod shortcut;
 mod tray;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,12 @@ pub fn run() {
                 let _ = w.hide();
             }
 
+            // Pré-aquece a janela Settings oculta. Criar janelas a partir de
+            // comandos tardiamente trava o build do WebView2 em alguns
+            // ambientes Windows; criar durante o setup garante inicialização
+            // limpa e abertura instantânea depois.
+            settings_window::prewarm(app.handle()).map_err(|e| format!("prewarm settings: {e}"))?;
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,6 +43,10 @@ pub fn run() {
             commands::get_config,
             commands::open_tab,
             commands::hide_donut,
+            commands::save_tab,
+            commands::delete_tab,
+            commands::open_settings,
+            commands::close_settings,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,6 +52,7 @@ pub fn run() {
             commands::save_tab,
             commands::delete_tab,
             commands::open_settings,
+            commands::consume_settings_intent,
             commands::close_settings,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,8 +29,15 @@ pub fn run() {
 
             tray::setup(app).map_err(|e| format!("tray: {e}"))?;
 
-            shortcut::register_from_config(app.handle(), &shortcut_str)
-                .map_err(|e| format!("shortcut: {e}"))?;
+            // Registro do atalho é best-effort. Falha típica (especialmente
+            // em dev, depois de um HMR de Rust) é o processo antigo ainda
+            // estar segurando o atalho quando o novo sobe. Seguimos em frente
+            // — tray e janelas continuam acessíveis.
+            if let Err(e) = shortcut::register_from_config(app.handle(), &shortcut_str) {
+                eprintln!(
+                    "[setup] shortcut registration failed ({e:?}); the global shortcut will be unavailable until the app is restarted"
+                );
+            }
 
             let _ = donut_window::show(app.handle());
             if let Some(w) = app.get_webview_window("donut") {
@@ -40,8 +47,13 @@ pub fn run() {
             // Pré-aquece a janela Settings oculta. Criar janelas a partir de
             // comandos tardiamente trava o build do WebView2 em alguns
             // ambientes Windows; criar durante o setup garante inicialização
-            // limpa e abertura instantânea depois.
-            settings_window::prewarm(app.handle()).map_err(|e| format!("prewarm settings: {e}"))?;
+            // limpa e abertura instantânea depois. Falha aqui é recuperável
+            // via fallback em `settings_window::show`.
+            if let Err(e) = settings_window::prewarm(app.handle()) {
+                eprintln!(
+                    "[setup] settings window prewarm failed ({e:?}); first open may be slower"
+                );
+            }
 
             Ok(())
         })

--- a/src-tauri/src/settings_window/mod.rs
+++ b/src-tauri/src/settings_window/mod.rs
@@ -55,11 +55,17 @@ pub fn show<R: Runtime>(app: &AppHandle<R>) -> AppResult<()> {
     Ok(())
 }
 
+/// Oculta a janela em vez de destruí-la: a janela é pré-aquecida no `setup()`
+/// para contornar o travamento do build do WebView2 em tempo de execução no
+/// Windows (ver `prewarm`). Destruí-la aqui forçaria recriação no próximo
+/// `show`, caindo no fallback `run_on_main_thread` — com o mesmo risco de
+/// trave. Do ponto de vista do usuário a janela some; internamente fica
+/// pronta para reabrir instantaneamente.
 pub fn close<R: Runtime>(app: &AppHandle<R>) -> AppResult<()> {
     if let Some(window) = app.get_webview_window(SETTINGS_LABEL) {
         window
-            .close()
-            .map_err(|e| AppError::window("window_close_failed", &[("reason", e.to_string())]))?;
+            .hide()
+            .map_err(|e| AppError::window("window_hide_failed", &[("reason", e.to_string())]))?;
     }
     Ok(())
 }

--- a/src-tauri/src/settings_window/mod.rs
+++ b/src-tauri/src/settings_window/mod.rs
@@ -5,6 +5,30 @@ pub const SETTINGS_LABEL: &str = "settings";
 const SETTINGS_MIN_SIZE: (f64, f64) = (720.0, 520.0);
 const SETTINGS_INITIAL_SIZE: (f64, f64) = (960.0, 640.0);
 
+/// Cria a janela Settings oculta. Deve ser chamada no `setup()` do Tauri.
+///
+/// Contexto: no Windows, `WebviewWindowBuilder::build()` para uma janela
+/// decorada normal trava silenciosamente quando invocado de um `#[tauri::command]`
+/// (thread do runtime async) *ou* de `run_on_main_thread` em tempo de execução.
+/// Criar a janela durante o `setup()` — quando o Tauri ainda está
+/// inicializando o loop nativo — funciona consistentemente. A janela fica
+/// oculta até o usuário abrir via tray ou engrenagem do donut.
+pub fn prewarm<R: Runtime>(app: &AppHandle<R>) -> AppResult<()> {
+    if app.get_webview_window(SETTINGS_LABEL).is_some() {
+        return Ok(());
+    }
+    WebviewWindowBuilder::new(app, SETTINGS_LABEL, WebviewUrl::App("settings.html".into()))
+        .title("DonutTabs — Configurações")
+        .inner_size(SETTINGS_INITIAL_SIZE.0, SETTINGS_INITIAL_SIZE.1)
+        .min_inner_size(SETTINGS_MIN_SIZE.0, SETTINGS_MIN_SIZE.1)
+        .resizable(true)
+        .decorations(true)
+        .visible(false)
+        .build()
+        .map_err(|e| AppError::window("window_build_failed", &[("reason", e.to_string())]))?;
+    Ok(())
+}
+
 pub fn show<R: Runtime>(app: &AppHandle<R>) -> AppResult<()> {
     if let Some(window) = app.get_webview_window(SETTINGS_LABEL) {
         window
@@ -16,16 +40,18 @@ pub fn show<R: Runtime>(app: &AppHandle<R>) -> AppResult<()> {
         return Ok(());
     }
 
-    WebviewWindowBuilder::new(app, SETTINGS_LABEL, WebviewUrl::App("settings.html".into()))
-        .title("DonutTabs — Configurações")
-        .inner_size(SETTINGS_INITIAL_SIZE.0, SETTINGS_INITIAL_SIZE.1)
-        .min_inner_size(SETTINGS_MIN_SIZE.0, SETTINGS_MIN_SIZE.1)
-        .resizable(true)
-        .decorations(true)
-        .visible(true)
-        .build()
-        .map_err(|e| AppError::window("window_build_failed", &[("reason", e.to_string())]))?;
-
+    // A janela deveria ter sido pré-aquecida no setup. Fallback: tenta criar
+    // agora na main thread. Em alguns ambientes Windows isso trava, mas é
+    // melhor do que falhar silenciosamente quando o pré-aquecimento não rodou.
+    let app_clone = app.clone();
+    app.run_on_main_thread(move || {
+        let _ = prewarm(&app_clone);
+        if let Some(window) = app_clone.get_webview_window(SETTINGS_LABEL) {
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+    })
+    .map_err(|e| AppError::window("run_on_main_thread_failed", &[("reason", e.to_string())]))?;
     Ok(())
 }
 

--- a/src-tauri/src/settings_window/mod.rs
+++ b/src-tauri/src/settings_window/mod.rs
@@ -1,0 +1,39 @@
+use crate::errors::{AppError, AppResult};
+use tauri::{AppHandle, Manager, Runtime, WebviewUrl, WebviewWindowBuilder};
+
+pub const SETTINGS_LABEL: &str = "settings";
+const SETTINGS_MIN_SIZE: (f64, f64) = (720.0, 520.0);
+const SETTINGS_INITIAL_SIZE: (f64, f64) = (960.0, 640.0);
+
+pub fn show<R: Runtime>(app: &AppHandle<R>) -> AppResult<()> {
+    if let Some(window) = app.get_webview_window(SETTINGS_LABEL) {
+        window
+            .show()
+            .map_err(|e| AppError::window("window_show_failed", &[("reason", e.to_string())]))?;
+        window.set_focus().map_err(|e| {
+            AppError::window("window_set_focus_failed", &[("reason", e.to_string())])
+        })?;
+        return Ok(());
+    }
+
+    WebviewWindowBuilder::new(app, SETTINGS_LABEL, WebviewUrl::App("settings.html".into()))
+        .title("DonutTabs — Configurações")
+        .inner_size(SETTINGS_INITIAL_SIZE.0, SETTINGS_INITIAL_SIZE.1)
+        .min_inner_size(SETTINGS_MIN_SIZE.0, SETTINGS_MIN_SIZE.1)
+        .resizable(true)
+        .decorations(true)
+        .visible(true)
+        .build()
+        .map_err(|e| AppError::window("window_build_failed", &[("reason", e.to_string())]))?;
+
+    Ok(())
+}
+
+pub fn close<R: Runtime>(app: &AppHandle<R>) -> AppResult<()> {
+    if let Some(window) = app.get_webview_window(SETTINGS_LABEL) {
+        window
+            .close()
+            .map_err(|e| AppError::window("window_close_failed", &[("reason", e.to_string())]))?;
+    }
+    Ok(())
+}

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -1,5 +1,6 @@
 use crate::donut_window;
 use crate::errors::{AppError, AppResult};
+use crate::settings_window;
 use tauri::{
     menu::{Menu, MenuItem},
     tray::TrayIconBuilder,
@@ -9,9 +10,11 @@ use tauri::{
 pub fn setup<R: Runtime>(app: &tauri::App<R>) -> AppResult<()> {
     let open = MenuItem::with_id(app, "open_donut", "Abrir donut", true, None::<&str>)
         .map_err(|e| AppError::window("tray_menu_item_failed", &[("reason", e.to_string())]))?;
+    let settings = MenuItem::with_id(app, "open_settings", "Configurações", true, None::<&str>)
+        .map_err(|e| AppError::window("tray_menu_item_failed", &[("reason", e.to_string())]))?;
     let quit = MenuItem::with_id(app, "quit", "Sair", true, None::<&str>)
         .map_err(|e| AppError::window("tray_menu_item_failed", &[("reason", e.to_string())]))?;
-    let menu = Menu::with_items(app, &[&open, &quit])
+    let menu = Menu::with_items(app, &[&open, &settings, &quit])
         .map_err(|e| AppError::window("tray_menu_failed", &[("reason", e.to_string())]))?;
 
     let _tray = TrayIconBuilder::new()
@@ -21,6 +24,9 @@ pub fn setup<R: Runtime>(app: &tauri::App<R>) -> AppResult<()> {
         .on_menu_event(move |app, event| match event.id.as_ref() {
             "open_donut" => {
                 let _ = donut_window::show(app);
+            }
+            "open_settings" => {
+                let _ = settings_window::show(app);
             }
             "quit" => {
                 app.exit(0);

--- a/src/core/ipc.ts
+++ b/src/core/ipc.ts
@@ -1,8 +1,15 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { Config } from "./types/Config";
+import type { Tab } from "./types/Tab";
 
 export const ipc = {
   getConfig: () => invoke<Config>("get_config"),
   openTab: (tabId: string) => invoke<void>("open_tab", { tabId }),
   hideDonut: () => invoke<void>("hide_donut"),
+  saveTab: (tab: Tab) => invoke<Config>("save_tab", { tab }),
+  deleteTab: (tabId: string) => invoke<Config>("delete_tab", { tabId }),
+  openSettings: () => invoke<void>("open_settings"),
+  closeSettings: () => invoke<void>("close_settings"),
 };
+
+export const CONFIG_CHANGED_EVENT = "config-changed";

--- a/src/core/ipc.ts
+++ b/src/core/ipc.ts
@@ -2,14 +2,19 @@ import { invoke } from "@tauri-apps/api/core";
 import type { Config } from "./types/Config";
 import type { Tab } from "./types/Tab";
 
+export type SettingsIntent = "new-tab";
+
 export const ipc = {
   getConfig: () => invoke<Config>("get_config"),
   openTab: (tabId: string) => invoke<void>("open_tab", { tabId }),
   hideDonut: () => invoke<void>("hide_donut"),
   saveTab: (tab: Tab) => invoke<Config>("save_tab", { tab }),
   deleteTab: (tabId: string) => invoke<Config>("delete_tab", { tabId }),
-  openSettings: () => invoke<void>("open_settings"),
+  openSettings: (intent?: SettingsIntent) =>
+    invoke<void>("open_settings", { intent: intent ?? null }),
+  consumeSettingsIntent: () => invoke<string | null>("consume_settings_intent"),
   closeSettings: () => invoke<void>("close_settings"),
 };
 
 export const CONFIG_CHANGED_EVENT = "config-changed";
+export const SETTINGS_INTENT_EVENT = "settings-intent";

--- a/src/donut/CenterCircle.tsx
+++ b/src/donut/CenterCircle.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 
 export interface CenterCircleProps {
-  cx: number; cy: number;
+  cx: number;
+  cy: number;
   r: number;
+  onGearClick?: () => void;
 }
 
-export const CenterCircle: React.FC<CenterCircleProps> = ({ cx, cy, r }) => (
+export const CenterCircle: React.FC<CenterCircleProps> = ({ cx, cy, r, onGearClick }) => (
   <g>
     <circle cx={cx} cy={cy} r={r} fill="#141a28" stroke="#3a4968" strokeWidth={1} />
     <line x1={cx} y1={cy - r} x2={cx} y2={cy + r} stroke="#3a4968" strokeWidth={1} />
@@ -16,13 +18,35 @@ export const CenterCircle: React.FC<CenterCircleProps> = ({ cx, cy, r }) => (
       dominantBaseline="middle"
       fontSize={28}
       fill="#777"
-      style={{ userSelect: "none" }}
+      style={{ userSelect: "none", pointerEvents: "none" }}
     >
       ⚙
     </text>
-    <g transform={`translate(${cx + r / 2}, ${cy - 3})`} stroke="#777" strokeWidth={1.8} fill="none" strokeLinecap="round">
+    <g
+      transform={`translate(${cx + r / 2}, ${cy - 3})`}
+      stroke="#777"
+      strokeWidth={1.8}
+      fill="none"
+      strokeLinecap="round"
+      pointerEvents="none"
+    >
       <circle cx={0} cy={-6} r={5} />
       <path d="M -9 12 A 10 10 0 0 1 9 12" />
     </g>
+    {onGearClick && (
+      <rect
+        data-testid="gear-hit"
+        x={cx - r}
+        y={cy - r}
+        width={r}
+        height={r * 2}
+        fill="transparent"
+        style={{ cursor: "pointer" }}
+        onClick={(e) => {
+          e.stopPropagation();
+          onGearClick();
+        }}
+      />
+    )}
   </g>
 );

--- a/src/donut/Donut.tsx
+++ b/src/donut/Donut.tsx
@@ -9,9 +9,10 @@ export interface DonutProps {
   tabs: Tab[];
   size: number;
   onSelect: (tabId: string) => void;
+  onOpenSettings?: () => void;
 }
 
-export const Donut: React.FC<DonutProps> = ({ tabs, size, onSelect }) => {
+export const Donut: React.FC<DonutProps> = ({ tabs, size, onSelect, onOpenSettings }) => {
   const cx = size / 2;
   const cy = size / 2;
   const outerR = size * 0.46;
@@ -52,7 +53,7 @@ export const Donut: React.FC<DonutProps> = ({ tabs, size, onSelect }) => {
           />
         );
       })}
-      <CenterCircle cx={cx} cy={cy} r={innerR * 0.85} />
+      <CenterCircle cx={cx} cy={cy} r={innerR * 0.85} onGearClick={onOpenSettings} />
     </svg>
   );
 };

--- a/src/donut/Donut.tsx
+++ b/src/donut/Donut.tsx
@@ -12,6 +12,8 @@ export interface DonutProps {
   onOpenSettings?: () => void;
 }
 
+const PLUS_KEY = "__plus__";
+
 export const Donut: React.FC<DonutProps> = ({ tabs, size, onSelect, onOpenSettings }) => {
   const cx = size / 2;
   const cy = size / 2;
@@ -19,10 +21,12 @@ export const Donut: React.FC<DonutProps> = ({ tabs, size, onSelect, onOpenSettin
   const innerR = size * 0.22;
 
   const ordered = [...tabs].sort((a, b) => a.order - b.order);
+  const total = ordered.length + 1; // +1 para a fatia "+"
+  const plusIndex = ordered.length;
 
   const { highlighted, onMouseMove, onMouseLeave } = useSliceHighlight({
     center: { x: cx, y: cy },
-    slices: ordered.length,
+    slices: total,
     innerRadius: innerR,
     outerRadius: outerR,
   });
@@ -36,7 +40,7 @@ export const Donut: React.FC<DonutProps> = ({ tabs, size, onSelect, onOpenSettin
       onMouseLeave={onMouseLeave}
     >
       {ordered.map((tab, i) => {
-        const { start, end } = sliceAngleRange(i, ordered.length);
+        const { start, end } = sliceAngleRange(i, total);
         return (
           <Slice
             key={tab.id}
@@ -53,6 +57,23 @@ export const Donut: React.FC<DonutProps> = ({ tabs, size, onSelect, onOpenSettin
           />
         );
       })}
+      {(() => {
+        const { start, end } = sliceAngleRange(plusIndex, total);
+        return (
+          <Slice
+            key={PLUS_KEY}
+            cx={cx}
+            cy={cy}
+            innerR={innerR}
+            outerR={outerR}
+            startAngle={start}
+            endAngle={end}
+            icon="+"
+            highlighted={highlighted === plusIndex}
+            onClick={() => onOpenSettings?.()}
+          />
+        );
+      })()}
       <CenterCircle cx={cx} cy={cy} r={innerR * 0.85} onGearClick={onOpenSettings} />
     </svg>
   );

--- a/src/donut/Donut.tsx
+++ b/src/donut/Donut.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { Tab } from "../core/types/Tab";
+import type { SettingsIntent } from "../core/ipc";
 import { Slice } from "./Slice";
 import { CenterCircle } from "./CenterCircle";
 import { sliceAngleRange } from "./geometry";
@@ -9,7 +10,7 @@ export interface DonutProps {
   tabs: Tab[];
   size: number;
   onSelect: (tabId: string) => void;
-  onOpenSettings?: () => void;
+  onOpenSettings?: (intent?: SettingsIntent) => void;
 }
 
 const PLUS_KEY = "__plus__";
@@ -70,7 +71,7 @@ export const Donut: React.FC<DonutProps> = ({ tabs, size, onSelect, onOpenSettin
             endAngle={end}
             icon="+"
             highlighted={highlighted === plusIndex}
-            onClick={() => onOpenSettings?.()}
+            onClick={() => onOpenSettings?.("new-tab")}
           />
         );
       })()}

--- a/src/donut/Slice.tsx
+++ b/src/donut/Slice.tsx
@@ -24,6 +24,7 @@ export const Slice: React.FC<SliceProps> = (p) => {
         data-testid="donut-slice"
         d={d}
         fill={p.highlighted ? "#2a3b5a" : "#1b2436"}
+        fillRule="evenodd"
         stroke="#3a4968"
         strokeWidth={1}
       />

--- a/src/donut/__tests__/Donut.test.tsx
+++ b/src/donut/__tests__/Donut.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { render } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
 import { Donut } from "../Donut";
 import type { Tab } from "../../core/types/Tab";
 
@@ -26,5 +26,21 @@ describe("Donut", () => {
     const { container } = render(<Donut tabs={[]} size={400} onSelect={() => {}} />);
     const paths = container.querySelectorAll('[data-testid="donut-slice"]');
     expect(paths.length).toBe(0);
+  });
+
+  it("does not render a gear hit area when onOpenSettings is not provided", () => {
+    const { container } = render(<Donut tabs={[]} size={400} onSelect={() => {}} />);
+    expect(container.querySelector('[data-testid="gear-hit"]')).toBeNull();
+  });
+
+  it("calls onOpenSettings when clicking the gear hit area", () => {
+    const onOpenSettings = vi.fn();
+    const { container } = render(
+      <Donut tabs={[]} size={400} onSelect={() => {}} onOpenSettings={onOpenSettings} />,
+    );
+    const hit = container.querySelector('[data-testid="gear-hit"]') as SVGRectElement;
+    expect(hit).not.toBeNull();
+    fireEvent.click(hit);
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/donut/__tests__/Donut.test.tsx
+++ b/src/donut/__tests__/Donut.test.tsx
@@ -15,17 +15,54 @@ function makeTab(id: string, name: string): Tab {
 }
 
 describe("Donut", () => {
-  it("renders one slice per tab", () => {
+  it("renders one slice per tab plus a trailing '+' slice", () => {
     const tabs = [makeTab("1", "A"), makeTab("2", "B"), makeTab("3", "C")];
     const { container } = render(<Donut tabs={tabs} size={400} onSelect={() => {}} />);
     const paths = container.querySelectorAll('[data-testid="donut-slice"]');
-    expect(paths.length).toBe(3);
+    expect(paths.length).toBe(4);
   });
 
-  it("renders empty donut when no tabs", () => {
+  it("renders a single '+' slice when no tabs are registered", () => {
     const { container } = render(<Donut tabs={[]} size={400} onSelect={() => {}} />);
     const paths = container.querySelectorAll('[data-testid="donut-slice"]');
-    expect(paths.length).toBe(0);
+    expect(paths.length).toBe(1);
+  });
+
+  it("clicking the '+' slice calls onOpenSettings", () => {
+    const onOpenSettings = vi.fn();
+    const onSelect = vi.fn();
+    const { container } = render(
+      <Donut
+        tabs={[]}
+        size={400}
+        onSelect={onSelect}
+        onOpenSettings={onOpenSettings}
+      />,
+    );
+    const plusSlice = container.querySelector(
+      '[data-testid="donut-slice"]',
+    ) as SVGPathElement;
+    fireEvent.click(plusSlice);
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("clicking a tab slice calls onSelect with the tab id", () => {
+    const onOpenSettings = vi.fn();
+    const onSelect = vi.fn();
+    const { container } = render(
+      <Donut
+        tabs={[makeTab("abc", "A")]}
+        size={400}
+        onSelect={onSelect}
+        onOpenSettings={onOpenSettings}
+      />,
+    );
+    const slices = container.querySelectorAll('[data-testid="donut-slice"]');
+    // slices[0] = tab "A", slices[1] = "+"
+    fireEvent.click(slices[0]);
+    expect(onSelect).toHaveBeenCalledWith("abc");
+    expect(onOpenSettings).not.toHaveBeenCalled();
   });
 
   it("does not render a gear hit area when onOpenSettings is not provided", () => {

--- a/src/donut/__tests__/geometry.test.ts
+++ b/src/donut/__tests__/geometry.test.ts
@@ -43,4 +43,18 @@ describe("arcPath", () => {
     expect(d.startsWith("M")).toBe(true);
     expect(d).toMatch(/A /);
   });
+
+  it("renders a full ring (two sub-paths) when the arc covers 2π", () => {
+    const d = arcPath({
+      cx: 200,
+      cy: 200,
+      innerR: 80,
+      outerR: 180,
+      startAngle: -Math.PI / 2,
+      endAngle: -Math.PI / 2 + Math.PI * 2,
+    });
+    // Dois sub-paths (outer + inner) significa dois "M" e dois "Z".
+    expect((d.match(/M /g) ?? []).length).toBe(2);
+    expect((d.match(/Z/g) ?? []).length).toBe(2);
+  });
 });

--- a/src/donut/geometry.ts
+++ b/src/donut/geometry.ts
@@ -34,7 +34,25 @@ export interface ArcPathOpts {
 
 export function arcPath(o: ArcPathOpts): string {
   const { cx, cy, innerR, outerR, startAngle, endAngle } = o;
-  const largeArc = endAngle - startAngle > Math.PI ? 1 : 0;
+  const delta = endAngle - startAngle;
+
+  // Caso degenerado: arco cobre o círculo inteiro. SVG não desenha um arco
+  // com start == end (vira um ponto/linha), então emitimos um anel fechado
+  // com dois sub-paths e `fill-rule="evenodd"` para recortar o miolo.
+  if (delta >= Math.PI * 2 - 1e-6) {
+    return [
+      `M ${cx + outerR} ${cy}`,
+      `A ${outerR} ${outerR} 0 1 1 ${cx - outerR} ${cy}`,
+      `A ${outerR} ${outerR} 0 1 1 ${cx + outerR} ${cy}`,
+      "Z",
+      `M ${cx + innerR} ${cy}`,
+      `A ${innerR} ${innerR} 0 1 0 ${cx - innerR} ${cy}`,
+      `A ${innerR} ${innerR} 0 1 0 ${cx + innerR} ${cy}`,
+      "Z",
+    ].join(" ");
+  }
+
+  const largeArc = delta > Math.PI ? 1 : 0;
   const x1 = cx + outerR * Math.cos(startAngle);
   const y1 = cy + outerR * Math.sin(startAngle);
   const x2 = cx + outerR * Math.cos(endAngle);

--- a/src/entry/donut.tsx
+++ b/src/entry/donut.tsx
@@ -74,8 +74,9 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
   const handleOpenSettings = async (intent?: import("../core/ipc").SettingsIntent) => {
     try {
       await ipc.openSettings(intent);
-    } finally {
       void ipc.hideDonut();
+    } catch (err) {
+      setErrorMsg(translateAppError(err, t));
     }
   };
 

--- a/src/entry/donut.tsx
+++ b/src/entry/donut.tsx
@@ -3,8 +3,9 @@ import { createRoot } from "react-dom/client";
 import { I18nextProvider, useTranslation } from "react-i18next";
 import i18next from "i18next";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { listen } from "@tauri-apps/api/event";
 import { Donut } from "../donut/Donut";
-import { ipc } from "../core/ipc";
+import { ipc, CONFIG_CHANGED_EVENT } from "../core/ipc";
 import { initI18n } from "../core/i18n";
 import { translateAppError } from "../core/errors";
 import type { Config } from "../core/types/Config";
@@ -45,6 +46,18 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
     };
   }, []);
 
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    void listen<Config>(CONFIG_CHANGED_EVENT, (e) => {
+      setConfig(e.payload);
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
   const handleBackdropClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) void ipc.hideDonut();
   };
@@ -55,6 +68,14 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
       void ipc.hideDonut();
     } catch (err) {
       setErrorMsg(translateAppError(err, t));
+    }
+  };
+
+  const handleOpenSettings = async () => {
+    try {
+      await ipc.openSettings();
+    } finally {
+      void ipc.hideDonut();
     }
   };
 
@@ -70,7 +91,12 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
       onClick={handleBackdropClick}
     >
       {config && (
-        <Donut tabs={config.tabs} size={WINDOW_SIZE} onSelect={handleSelect} />
+        <Donut
+          tabs={config.tabs}
+          size={WINDOW_SIZE}
+          onSelect={handleSelect}
+          onOpenSettings={handleOpenSettings}
+        />
       )}
       {errorMsg && (
         <div

--- a/src/entry/donut.tsx
+++ b/src/entry/donut.tsx
@@ -71,9 +71,9 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
     }
   };
 
-  const handleOpenSettings = async () => {
+  const handleOpenSettings = async (intent?: import("../core/ipc").SettingsIntent) => {
     try {
-      await ipc.openSettings();
+      await ipc.openSettings(intent);
     } finally {
       void ipc.hideDonut();
     }

--- a/src/entry/settings.tsx
+++ b/src/entry/settings.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from "react-dom/client";
+
+createRoot(document.getElementById("root")!).render(
+  <div style={{ padding: 24 }}>DonutTabs — Settings (wip)</div>,
+);

--- a/src/entry/settings.tsx
+++ b/src/entry/settings.tsx
@@ -1,5 +1,28 @@
 import { createRoot } from "react-dom/client";
+import { I18nextProvider } from "react-i18next";
+import i18next from "i18next";
+import { ipc } from "../core/ipc";
+import { initI18n } from "../core/i18n";
+import { SettingsApp } from "../settings/SettingsApp";
+import type { Config } from "../core/types/Config";
 
-createRoot(document.getElementById("root")!).render(
-  <div style={{ padding: 24 }}>DonutTabs — Settings (wip)</div>,
-);
+async function bootstrap() {
+  let language: Config["appearance"]["language"] = "auto";
+  try {
+    const cfg = await ipc.getConfig();
+    language = cfg.appearance.language;
+  } catch (e) {
+    console.error("getConfig failed during settings bootstrap; using auto", e);
+  }
+  await initI18n(language);
+
+  document.title = i18next.t("settings.title");
+
+  createRoot(document.getElementById("root")!).render(
+    <I18nextProvider i18n={i18next}>
+      <SettingsApp />
+    </I18nextProvider>,
+  );
+}
+
+void bootstrap();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -61,6 +61,7 @@
       "delete": "Delete",
       "confirmDelete": "Delete tab \"{{label}}\"? This cannot be undone.",
       "validationNameOrIcon": "Provide a name or an icon.",
+      "validationIconTooLong": "The icon must be a single character or emoji.",
       "validationAtLeastOneUrl": "Add at least one URL.",
       "validationInvalidUrl": "Invalid URL: {{value}}"
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -31,5 +31,38 @@
   },
   "donut": {
     "toastDismiss": "Close"
+  },
+  "settings": {
+    "title": "Settings",
+    "tabs": {
+      "sectionTitle": "Tabs",
+      "addTab": "Add tab",
+      "empty": "No tabs yet. Click \"Add tab\" to begin.",
+      "selectPrompt": "Select a tab to edit, or click \"Add tab\"."
+    },
+    "editor": {
+      "newTabTitle": "New tab",
+      "name": "Name",
+      "namePlaceholder": "Work",
+      "icon": "Icon",
+      "iconPlaceholder": "💼",
+      "iconHint": "An emoji or short character. Name or icon is required.",
+      "openMode": "Open mode",
+      "openModeReuseOrNewWindow": "Reuse or new window",
+      "openModeNewWindow": "New window",
+      "openModeNewTab": "New tab",
+      "urls": "URLs",
+      "urlPlaceholder": "https://…",
+      "addUrl": "Add URL",
+      "removeUrl": "Remove URL",
+      "save": "Save",
+      "saving": "Saving…",
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "confirmDelete": "Delete tab \"{{label}}\"? This cannot be undone.",
+      "validationNameOrIcon": "Provide a name or an icon.",
+      "validationAtLeastOneUrl": "Add at least one URL.",
+      "validationInvalidUrl": "Invalid URL: {{value}}"
+    }
   }
 }

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -61,6 +61,7 @@
       "delete": "Excluir",
       "confirmDelete": "Excluir aba \"{{label}}\"? Essa ação não pode ser desfeita.",
       "validationNameOrIcon": "Preencha nome ou ícone.",
+      "validationIconTooLong": "Use apenas um único caractere ou emoji no ícone.",
       "validationAtLeastOneUrl": "Adicione ao menos uma URL.",
       "validationInvalidUrl": "URL inválida: {{value}}"
     }

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -31,5 +31,38 @@
   },
   "donut": {
     "toastDismiss": "Fechar"
+  },
+  "settings": {
+    "title": "Configurações",
+    "tabs": {
+      "sectionTitle": "Abas",
+      "addTab": "Adicionar aba",
+      "empty": "Nenhuma aba cadastrada. Clique em \"Adicionar aba\" para começar.",
+      "selectPrompt": "Selecione uma aba para editar ou clique em \"Adicionar aba\"."
+    },
+    "editor": {
+      "newTabTitle": "Nova aba",
+      "name": "Nome",
+      "namePlaceholder": "Trabalho",
+      "icon": "Ícone",
+      "iconPlaceholder": "💼",
+      "iconHint": "Um emoji ou caractere curto. Nome ou ícone são obrigatórios.",
+      "openMode": "Modo de abertura",
+      "openModeReuseOrNewWindow": "Reutilizar ou nova janela",
+      "openModeNewWindow": "Nova janela",
+      "openModeNewTab": "Nova aba",
+      "urls": "URLs",
+      "urlPlaceholder": "https://…",
+      "addUrl": "Adicionar URL",
+      "removeUrl": "Remover URL",
+      "save": "Salvar",
+      "saving": "Salvando…",
+      "cancel": "Cancelar",
+      "delete": "Excluir",
+      "confirmDelete": "Excluir aba \"{{label}}\"? Essa ação não pode ser desfeita.",
+      "validationNameOrIcon": "Preencha nome ou ícone.",
+      "validationAtLeastOneUrl": "Adicione ao menos uma URL.",
+      "validationInvalidUrl": "URL inválida: {{value}}"
+    }
   }
 }

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { TabList } from "./TabList";
+import { TabEditor } from "./TabEditor";
+import { useConfig } from "./useConfig";
+import type { Tab } from "../core/types/Tab";
+
+type Selection =
+  | { mode: "empty" }
+  | { mode: "new" }
+  | { mode: "edit"; tabId: string };
+
+export const SettingsApp: React.FC = () => {
+  const { t } = useTranslation();
+  const { config, saveTab, deleteTab } = useConfig();
+  const [selection, setSelection] = useState<Selection>({ mode: "empty" });
+
+  if (!config) {
+    return <div style={{ padding: 24 }}>…</div>;
+  }
+
+  const selectedTab: Tab | null =
+    selection.mode === "edit"
+      ? config.tabs.find((tab) => tab.id === selection.tabId) ?? null
+      : null;
+
+  const handleSave = async (tab: Tab) => {
+    await saveTab(tab);
+    setSelection({ mode: "edit", tabId: tab.id });
+  };
+
+  const handleDelete = async (tabId: string) => {
+    await deleteTab(tabId);
+    setSelection({ mode: "empty" });
+  };
+
+  return (
+    <div style={{ display: "flex", height: "100vh" }}>
+      <TabList
+        tabs={config.tabs}
+        selectedId={selection.mode === "edit" ? selection.tabId : null}
+        onSelect={(id) => setSelection({ mode: "edit", tabId: id })}
+        onAdd={() => setSelection({ mode: "new" })}
+      />
+      {selection.mode === "new" ? (
+        <TabEditor
+          mode="new"
+          initial={null}
+          onSave={handleSave}
+          onCancel={() => setSelection({ mode: "empty" })}
+          onDelete={handleDelete}
+        />
+      ) : selection.mode === "edit" && selectedTab ? (
+        <TabEditor
+          mode="edit"
+          initial={selectedTab}
+          onSave={handleSave}
+          onCancel={() => setSelection({ mode: "empty" })}
+          onDelete={handleDelete}
+        />
+      ) : (
+        <section
+          style={{
+            flex: 1,
+            display: "grid",
+            placeItems: "center",
+            color: "#889",
+            padding: 24,
+            textAlign: "center",
+          }}
+        >
+          {t("settings.tabs.selectPrompt")}
+        </section>
+      )}
+    </div>
+  );
+};

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -1,8 +1,10 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { listen } from "@tauri-apps/api/event";
 import { TabList } from "./TabList";
 import { TabEditor } from "./TabEditor";
 import { useConfig } from "./useConfig";
+import { ipc, SETTINGS_INTENT_EVENT } from "../core/ipc";
 import type { Tab } from "../core/types/Tab";
 
 type Selection =
@@ -10,10 +12,32 @@ type Selection =
   | { mode: "new" }
   | { mode: "edit"; tabId: string };
 
+function applyIntent(intent: string | null, setSelection: (s: Selection) => void) {
+  if (intent === "new-tab") {
+    setSelection({ mode: "new" });
+  }
+}
+
 export const SettingsApp: React.FC = () => {
   const { t } = useTranslation();
   const { config, saveTab, deleteTab } = useConfig();
   const [selection, setSelection] = useState<Selection>({ mode: "empty" });
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    // Primeiro registra o listener, depois consome qualquer intent pendente
+    // no AppState. Assim eventos emitidos durante a janela de "consume" não
+    // são perdidos.
+    void listen<string>(SETTINGS_INTENT_EVENT, (e) => {
+      applyIntent(e.payload, setSelection);
+    }).then((fn) => {
+      unlisten = fn;
+      void ipc.consumeSettingsIntent().then((intent) => {
+        applyIntent(intent, setSelection);
+      });
+    });
+    return () => unlisten?.();
+  }, []);
 
   if (!config) {
     return <div style={{ padding: 24 }}>…</div>;

--- a/src/settings/TabEditor.tsx
+++ b/src/settings/TabEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { UrlListEditor } from "./UrlListEditor";
 import { translateAppError } from "../core/errors";
@@ -23,10 +23,29 @@ interface FormState {
   urls: string[];
 }
 
-const OPEN_MODES: OpenMode[] = ["reuseOrNewWindow", "newWindow", "newTab"];
-
 function randomUuid(): string {
   return crypto.randomUUID();
+}
+
+function graphemeCount(s: string): number {
+  // Intl.Segmenter cobre emojis compostos (ZWJ, skin tone, bandeiras).
+  // Fallback para contagem de codepoints em runtimes sem Segmenter.
+  const IntlAny = Intl as unknown as {
+    Segmenter?: new (
+      locale: string,
+      opts: { granularity: "grapheme" },
+    ) => { segment: (s: string) => Iterable<unknown> };
+  };
+  if (IntlAny.Segmenter) {
+    let count = 0;
+    for (const _ of new IntlAny.Segmenter("pt-BR", { granularity: "grapheme" }).segment(
+      s,
+    )) {
+      count++;
+    }
+    return count;
+  }
+  return [...s].length;
 }
 
 function fromTab(tab: Tab | null): FormState {
@@ -69,15 +88,6 @@ export const TabEditor: React.FC<TabEditorProps> = ({
     setServerError(null);
   }, [initial, mode]);
 
-  const openModeLabels = useMemo<Record<OpenMode, string>>(
-    () => ({
-      reuseOrNewWindow: t("settings.editor.openModeReuseOrNewWindow"),
-      newWindow: t("settings.editor.openModeNewWindow"),
-      newTab: t("settings.editor.openModeNewTab"),
-    }),
-    [t],
-  );
-
   const submit = async () => {
     setServerError(null);
 
@@ -85,6 +95,11 @@ export const TabEditor: React.FC<TabEditorProps> = ({
     const icon = state.icon.trim();
     if (!name && !icon) {
       setValidation(t("settings.editor.validationNameOrIcon"));
+      return;
+    }
+
+    if (icon && graphemeCount(icon) > 1) {
+      setValidation(t("settings.editor.validationIconTooLong"));
       return;
     }
 
@@ -178,26 +193,13 @@ export const TabEditor: React.FC<TabEditorProps> = ({
             value={state.icon}
             onChange={(e) => setState({ ...state, icon: e.target.value })}
             placeholder={t("settings.editor.iconPlaceholder")}
-            style={{ ...inputStyle, width: 120 }}
+            maxLength={16}
+            size={4}
+            style={{ ...inputStyle, width: 80 }}
           />
         </label>
         <small style={{ color: "#889" }}>{t("settings.editor.iconHint")}</small>
       </div>
-
-      <fieldset style={{ border: "1px solid #2a3557", borderRadius: 4, padding: 12 }}>
-        <legend style={{ padding: "0 6px" }}>{t("settings.editor.openMode")}</legend>
-        {OPEN_MODES.map((m) => (
-          <label key={m} style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}>
-            <input
-              type="radio"
-              name="openMode"
-              checked={state.openMode === m}
-              onChange={() => setState({ ...state, openMode: m })}
-            />
-            {openModeLabels[m]}
-          </label>
-        ))}
-      </fieldset>
 
       <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
         <span>{t("settings.editor.urls")}</span>

--- a/src/settings/TabEditor.tsx
+++ b/src/settings/TabEditor.tsx
@@ -1,0 +1,268 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { UrlListEditor } from "./UrlListEditor";
+import { translateAppError } from "../core/errors";
+import type { Tab } from "../core/types/Tab";
+import type { OpenMode } from "../core/types/OpenMode";
+
+type Mode = "new" | "edit";
+
+export interface TabEditorProps {
+  mode: Mode;
+  initial: Tab | null;
+  onSave: (tab: Tab) => Promise<void>;
+  onCancel: () => void;
+  onDelete: (tabId: string) => Promise<void>;
+}
+
+interface FormState {
+  id: string;
+  name: string;
+  icon: string;
+  openMode: OpenMode;
+  urls: string[];
+}
+
+const OPEN_MODES: OpenMode[] = ["reuseOrNewWindow", "newWindow", "newTab"];
+
+function randomUuid(): string {
+  return crypto.randomUUID();
+}
+
+function fromTab(tab: Tab | null): FormState {
+  if (!tab) {
+    return {
+      id: randomUuid(),
+      name: "",
+      icon: "",
+      openMode: "reuseOrNewWindow",
+      urls: [""],
+    };
+  }
+  return {
+    id: tab.id,
+    name: tab.name ?? "",
+    icon: tab.icon ?? "",
+    openMode: tab.openMode,
+    urls: tab.items.length
+      ? tab.items.map((it) => (it.kind === "url" ? it.value : ""))
+      : [""],
+  };
+}
+
+export const TabEditor: React.FC<TabEditorProps> = ({
+  mode,
+  initial,
+  onSave,
+  onCancel,
+  onDelete,
+}) => {
+  const { t } = useTranslation();
+  const [state, setState] = useState<FormState>(() => fromTab(initial));
+  const [validation, setValidation] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setState(fromTab(initial));
+    setValidation(null);
+    setServerError(null);
+  }, [initial, mode]);
+
+  const openModeLabels = useMemo<Record<OpenMode, string>>(
+    () => ({
+      reuseOrNewWindow: t("settings.editor.openModeReuseOrNewWindow"),
+      newWindow: t("settings.editor.openModeNewWindow"),
+      newTab: t("settings.editor.openModeNewTab"),
+    }),
+    [t],
+  );
+
+  const submit = async () => {
+    setServerError(null);
+
+    const name = state.name.trim();
+    const icon = state.icon.trim();
+    if (!name && !icon) {
+      setValidation(t("settings.editor.validationNameOrIcon"));
+      return;
+    }
+
+    const urls = state.urls.map((u) => u.trim()).filter((u) => u.length > 0);
+    if (urls.length === 0) {
+      setValidation(t("settings.editor.validationAtLeastOneUrl"));
+      return;
+    }
+
+    for (const u of urls) {
+      try {
+        new URL(u);
+      } catch {
+        setValidation(t("settings.editor.validationInvalidUrl", { value: u }));
+        return;
+      }
+    }
+
+    setValidation(null);
+
+    const payload: Tab = {
+      id: state.id,
+      name: name.length > 0 ? name : null,
+      icon: icon.length > 0 ? icon : null,
+      order: initial?.order ?? 0,
+      openMode: state.openMode,
+      items: urls.map((value) => ({ kind: "url", value })),
+    };
+
+    setSaving(true);
+    try {
+      await onSave(payload);
+    } catch (err) {
+      setServerError(translateAppError(err, t));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const requestDelete = async () => {
+    if (!initial) return;
+    const label = initial.name ?? initial.icon ?? initial.id.slice(0, 6);
+    const confirmed = window.confirm(t("settings.editor.confirmDelete", { label }));
+    if (!confirmed) return;
+    try {
+      await onDelete(initial.id);
+    } catch (err) {
+      setServerError(translateAppError(err, t));
+    }
+  };
+
+  const title =
+    mode === "new" ? t("settings.editor.newTabTitle") : state.name || state.icon || "";
+
+  const inputStyle: React.CSSProperties = {
+    background: "#12192c",
+    color: "#dde",
+    border: "1px solid #2a3557",
+    borderRadius: 4,
+    padding: "6px 8px",
+    font: "inherit",
+  };
+
+  return (
+    <section
+      style={{
+        flex: 1,
+        padding: 24,
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+        overflow: "auto",
+      }}
+    >
+      <h2 style={{ margin: 0 }}>{title}</h2>
+
+      <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <span>{t("settings.editor.name")}</span>
+        <input
+          value={state.name}
+          onChange={(e) => setState({ ...state, name: e.target.value })}
+          placeholder={t("settings.editor.namePlaceholder")}
+          style={inputStyle}
+        />
+      </label>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span>{t("settings.editor.icon")}</span>
+          <input
+            value={state.icon}
+            onChange={(e) => setState({ ...state, icon: e.target.value })}
+            placeholder={t("settings.editor.iconPlaceholder")}
+            style={{ ...inputStyle, width: 120 }}
+          />
+        </label>
+        <small style={{ color: "#889" }}>{t("settings.editor.iconHint")}</small>
+      </div>
+
+      <fieldset style={{ border: "1px solid #2a3557", borderRadius: 4, padding: 12 }}>
+        <legend style={{ padding: "0 6px" }}>{t("settings.editor.openMode")}</legend>
+        {OPEN_MODES.map((m) => (
+          <label key={m} style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}>
+            <input
+              type="radio"
+              name="openMode"
+              checked={state.openMode === m}
+              onChange={() => setState({ ...state, openMode: m })}
+            />
+            {openModeLabels[m]}
+          </label>
+        ))}
+      </fieldset>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <span>{t("settings.editor.urls")}</span>
+        <UrlListEditor values={state.urls} onChange={(urls) => setState({ ...state, urls })} />
+      </div>
+
+      {validation && (
+        <div role="alert" style={{ color: "#f99" }}>
+          {validation}
+        </div>
+      )}
+      {serverError && (
+        <div role="alert" style={{ color: "#f99" }}>
+          {serverError}
+        </div>
+      )}
+
+      <footer style={{ display: "flex", gap: 8, marginTop: "auto" }}>
+        <button
+          type="button"
+          disabled={saving}
+          onClick={submit}
+          style={{
+            background: "#2a4a7d",
+            color: "#fff",
+            border: 0,
+            borderRadius: 4,
+            padding: "8px 16px",
+            cursor: saving ? "wait" : "pointer",
+          }}
+        >
+          {saving ? t("settings.editor.saving") : t("settings.editor.save")}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          style={{
+            background: "transparent",
+            color: "#dde",
+            border: "1px solid #334",
+            borderRadius: 4,
+            padding: "8px 16px",
+            cursor: "pointer",
+          }}
+        >
+          {t("settings.editor.cancel")}
+        </button>
+        {mode === "edit" && initial && (
+          <button
+            type="button"
+            onClick={requestDelete}
+            style={{
+              marginLeft: "auto",
+              background: "transparent",
+              color: "#f99",
+              border: "1px solid #532",
+              borderRadius: 4,
+              padding: "8px 16px",
+              cursor: "pointer",
+            }}
+          >
+            {t("settings.editor.delete")}
+          </button>
+        )}
+      </footer>
+    </section>
+  );
+};

--- a/src/settings/TabEditor.tsx
+++ b/src/settings/TabEditor.tsx
@@ -27,6 +27,12 @@ function randomUuid(): string {
   return crypto.randomUUID();
 }
 
+function stripLetters(s: string): string {
+  // \p{L} cobre letras de qualquer script (Latin, Cyrillic, CJK, etc.).
+  // Emojis ficam em \p{So}, ZWJ em \p{Cf}, modifiers em \p{Sk} — passam intactos.
+  return s.replace(/\p{L}/gu, "");
+}
+
 function graphemeCount(s: string): number {
   // Intl.Segmenter cobre emojis compostos (ZWJ, skin tone, bandeiras).
   // Fallback para contagem de codepoints em runtimes sem Segmenter.
@@ -191,7 +197,9 @@ export const TabEditor: React.FC<TabEditorProps> = ({
           <span>{t("settings.editor.icon")}</span>
           <input
             value={state.icon}
-            onChange={(e) => setState({ ...state, icon: e.target.value })}
+            onChange={(e) =>
+              setState({ ...state, icon: stripLetters(e.target.value) })
+            }
             placeholder={t("settings.editor.iconPlaceholder")}
             maxLength={16}
             size={4}

--- a/src/settings/TabList.tsx
+++ b/src/settings/TabList.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import type { Tab } from "../core/types/Tab";
+
+export interface TabListProps {
+  tabs: Tab[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onAdd: () => void;
+}
+
+export const TabList: React.FC<TabListProps> = ({ tabs, selectedId, onSelect, onAdd }) => {
+  const { t } = useTranslation();
+  const ordered = [...tabs].sort((a, b) => a.order - b.order);
+
+  return (
+    <aside
+      style={{
+        width: 260,
+        borderRight: "1px solid #23304d",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        padding: 12,
+        background: "#0c1020",
+      }}
+    >
+      <header
+        style={{
+          fontSize: 13,
+          color: "#8ea",
+          textTransform: "uppercase",
+          letterSpacing: 0.5,
+        }}
+      >
+        {t("settings.tabs.sectionTitle")}
+      </header>
+      <button
+        type="button"
+        onClick={onAdd}
+        style={{
+          background: "#1d2a4a",
+          color: "#dde",
+          border: "1px solid #334",
+          borderRadius: 6,
+          padding: "8px 10px",
+          cursor: "pointer",
+          font: "inherit",
+          textAlign: "left",
+        }}
+      >
+        + {t("settings.tabs.addTab")}
+      </button>
+
+      {ordered.length === 0 ? (
+        <p style={{ color: "#889", fontSize: 13, lineHeight: 1.4 }}>
+          {t("settings.tabs.empty")}
+        </p>
+      ) : (
+        <ul
+          style={{
+            listStyle: "none",
+            padding: 0,
+            margin: 0,
+            display: "flex",
+            flexDirection: "column",
+            gap: 4,
+          }}
+        >
+          {ordered.map((tab) => {
+            const selected = tab.id === selectedId;
+            const label = tab.name ?? tab.icon ?? tab.id.slice(0, 6);
+            return (
+              <li key={tab.id}>
+                <button
+                  type="button"
+                  data-testid="tab-row"
+                  data-selected={selected ? "true" : "false"}
+                  onClick={() => onSelect(tab.id)}
+                  style={{
+                    width: "100%",
+                    textAlign: "left",
+                    background: selected ? "#253e6b" : "transparent",
+                    color: "#dde",
+                    border: "1px solid " + (selected ? "#3e63a8" : "transparent"),
+                    borderRadius: 6,
+                    padding: "8px 10px",
+                    cursor: "pointer",
+                    font: "inherit",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                  }}
+                >
+                  <span style={{ width: 20, textAlign: "center" }}>{tab.icon ?? "•"}</span>
+                  <span
+                    style={{
+                      flex: 1,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {label}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </aside>
+  );
+};

--- a/src/settings/UrlListEditor.tsx
+++ b/src/settings/UrlListEditor.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+export interface UrlListEditorProps {
+  values: string[];
+  onChange: (next: string[]) => void;
+}
+
+export const UrlListEditor: React.FC<UrlListEditorProps> = ({ values, onChange }) => {
+  const { t } = useTranslation();
+
+  const update = (i: number, v: string) => {
+    const next = [...values];
+    next[i] = v;
+    onChange(next);
+  };
+
+  const remove = (i: number) => {
+    const next = values.filter((_, idx) => idx !== i);
+    onChange(next);
+  };
+
+  const add = () => onChange([...values, ""]);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      {values.map((v, i) => (
+        <div key={i} style={{ display: "flex", gap: 6 }}>
+          <input
+            aria-label={`URL ${i + 1}`}
+            value={v}
+            onChange={(e) => update(i, e.target.value)}
+            placeholder={t("settings.editor.urlPlaceholder")}
+            style={{
+              flex: 1,
+              background: "#12192c",
+              color: "#dde",
+              border: "1px solid #2a3557",
+              borderRadius: 4,
+              padding: "6px 8px",
+              font: "inherit",
+            }}
+          />
+          <button
+            type="button"
+            aria-label={t("settings.editor.removeUrl")}
+            onClick={() => remove(i)}
+            style={{
+              background: "transparent",
+              color: "#a77",
+              border: "1px solid #532",
+              borderRadius: 4,
+              padding: "4px 10px",
+              cursor: "pointer",
+            }}
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={add}
+        style={{
+          alignSelf: "flex-start",
+          background: "transparent",
+          color: "#8ea",
+          border: "1px dashed #355",
+          borderRadius: 4,
+          padding: "4px 10px",
+          cursor: "pointer",
+          fontSize: 12,
+        }}
+      >
+        + {t("settings.editor.addUrl")}
+      </button>
+    </div>
+  );
+};

--- a/src/settings/__tests__/SettingsApp.test.tsx
+++ b/src/settings/__tests__/SettingsApp.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { I18nextProvider } from "react-i18next";
+import { createI18n } from "../../core/i18n";
+import { SettingsApp } from "../SettingsApp";
+
+type Listener = (e: { payload: unknown }) => void;
+
+vi.mock("@tauri-apps/api/event", () => {
+  const listeners = new Map<string, Set<Listener>>();
+  return {
+    listen: vi.fn(async (name: string, cb: Listener) => {
+      const set = listeners.get(name) ?? new Set<Listener>();
+      set.add(cb);
+      listeners.set(name, set);
+      return () => {
+        set.delete(cb);
+      };
+    }),
+    __emit: (name: string, payload: unknown) => {
+      listeners.get(name)?.forEach((cb) => cb({ payload }));
+    },
+  };
+});
+
+vi.mock("../../core/ipc", () => ({
+  ipc: {
+    getConfig: vi.fn(),
+    saveTab: vi.fn(),
+    deleteTab: vi.fn(),
+    openSettings: vi.fn(),
+    closeSettings: vi.fn(),
+    openTab: vi.fn(),
+    hideDonut: vi.fn(),
+    consumeSettingsIntent: vi.fn().mockResolvedValue(null),
+  },
+  CONFIG_CHANGED_EVENT: "config-changed",
+  SETTINGS_INTENT_EVENT: "settings-intent",
+}));
+
+import { ipc } from "../../core/ipc";
+import * as events from "@tauri-apps/api/event";
+
+const makeConfig = () => ({
+  version: 1,
+  shortcut: "CommandOrControl+Shift+Space",
+  appearance: { theme: "dark", language: "auto" },
+  interaction: {
+    spawnPosition: "cursor",
+    selectionMode: "clickOrRelease",
+    hoverHoldMs: 800,
+  },
+  pagination: { itemsPerPage: 6, wheelDirection: "standard" },
+  system: { autostart: false },
+  tabs: [],
+});
+
+async function renderApp() {
+  const i18n = await createI18n("pt-BR");
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <SettingsApp />
+    </I18nextProvider>,
+  );
+}
+
+describe("SettingsApp intent routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (ipc.consumeSettingsIntent as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  });
+
+  it("defaults to the select-prompt view when no intent is pending", async () => {
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(makeConfig());
+    await renderApp();
+    await waitFor(() => {
+      expect(screen.getByText(/selecione uma aba/i)).toBeTruthy();
+    });
+  });
+
+  it("opens the new-tab editor when the pending intent is 'new-tab'", async () => {
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(makeConfig());
+    (ipc.consumeSettingsIntent as ReturnType<typeof vi.fn>).mockResolvedValue("new-tab");
+    await renderApp();
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /nova aba/i })).toBeTruthy();
+    });
+  });
+
+  it("switches to new-tab editor when receiving a live settings-intent event", async () => {
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(makeConfig());
+    await renderApp();
+    // começa no select-prompt
+    await waitFor(() => {
+      expect(screen.getByText(/selecione uma aba/i)).toBeTruthy();
+    });
+    act(() => {
+      (events as unknown as { __emit: (n: string, p: unknown) => void }).__emit(
+        "settings-intent",
+        "new-tab",
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /nova aba/i })).toBeTruthy();
+    });
+  });
+});

--- a/src/settings/__tests__/SettingsApp.test.tsx
+++ b/src/settings/__tests__/SettingsApp.test.tsx
@@ -20,6 +20,9 @@ vi.mock("@tauri-apps/api/event", () => {
     __emit: (name: string, payload: unknown) => {
       listeners.get(name)?.forEach((cb) => cb({ payload }));
     },
+    __reset: () => {
+      listeners.clear();
+    },
   };
 });
 
@@ -67,6 +70,7 @@ async function renderApp() {
 describe("SettingsApp intent routing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (events as unknown as { __reset: () => void }).__reset();
     (ipc.consumeSettingsIntent as ReturnType<typeof vi.fn>).mockResolvedValue(null);
   });
 

--- a/src/settings/__tests__/TabEditor.test.tsx
+++ b/src/settings/__tests__/TabEditor.test.tsx
@@ -105,4 +105,35 @@ describe("TabEditor", () => {
     await renderEditor({ mode: "new" });
     expect(screen.queryByRole("button", { name: /^excluir$/i })).toBeNull();
   });
+
+  it("rejects an icon with more than one grapheme", async () => {
+    const user = userEvent.setup();
+    const { props } = await renderEditor();
+    await user.type(screen.getByLabelText(/ícone/i), "ab");
+    await user.type(screen.getByLabelText(/url 1/i), "https://a.test");
+    await user.click(screen.getByRole("button", { name: /^salvar$/i }));
+    expect(screen.getByText(/único caractere ou emoji/i)).toBeTruthy();
+    expect(props.onSave).not.toHaveBeenCalled();
+  });
+
+  it("accepts a compound emoji as a single grapheme", async () => {
+    const user = userEvent.setup();
+    const { props } = await renderEditor();
+    // bandeira do Brasil: 2 codepoints, 1 grafema
+    await user.type(screen.getByLabelText(/ícone/i), "🇧🇷");
+    await user.type(screen.getByLabelText(/url 1/i), "https://a.test");
+    await user.click(screen.getByRole("button", { name: /^salvar$/i }));
+    expect(props.onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("icon input caps UTF-16 length at 16", async () => {
+    await renderEditor();
+    const iconInput = screen.getByLabelText(/ícone/i) as HTMLInputElement;
+    expect(iconInput.maxLength).toBe(16);
+  });
+
+  it("does not render the open-mode selector", async () => {
+    await renderEditor();
+    expect(screen.queryByText(/modo de abertura/i)).toBeNull();
+  });
 });

--- a/src/settings/__tests__/TabEditor.test.tsx
+++ b/src/settings/__tests__/TabEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nextProvider } from "react-i18next";
 import type { ComponentProps } from "react";
@@ -109,7 +109,10 @@ describe("TabEditor", () => {
   it("rejects an icon with more than one grapheme", async () => {
     const user = userEvent.setup();
     const { props } = await renderEditor();
-    await user.type(screen.getByLabelText(/ícone/i), "ab");
+    // dois emojis passam pelo filtro de letras mas falham na contagem de grafemas
+    fireEvent.change(screen.getByLabelText(/ícone/i), {
+      target: { value: "💼📝" },
+    });
     await user.type(screen.getByLabelText(/url 1/i), "https://a.test");
     await user.click(screen.getByRole("button", { name: /^salvar$/i }));
     expect(screen.getByText(/único caractere ou emoji/i)).toBeTruthy();
@@ -135,5 +138,29 @@ describe("TabEditor", () => {
   it("does not render the open-mode selector", async () => {
     await renderEditor();
     expect(screen.queryByText(/modo de abertura/i)).toBeNull();
+  });
+
+  it("does not let letters appear in the icon input as they are typed", async () => {
+    const user = userEvent.setup();
+    await renderEditor();
+    const iconInput = screen.getByLabelText(/ícone/i) as HTMLInputElement;
+    await user.type(iconInput, "abc");
+    expect(iconInput.value).toBe("");
+  });
+
+  it("strips letters but keeps emoji when the value is set from a paste", async () => {
+    await renderEditor();
+    const iconInput = screen.getByLabelText(/ícone/i) as HTMLInputElement;
+    fireEvent.change(iconInput, { target: { value: "💼Work" } });
+    expect(iconInput.value).toBe("💼");
+  });
+
+  it("keeps non-letter symbols like '★' and '→'", async () => {
+    await renderEditor();
+    const iconInput = screen.getByLabelText(/ícone/i) as HTMLInputElement;
+    fireEvent.change(iconInput, { target: { value: "★" } });
+    expect(iconInput.value).toBe("★");
+    fireEvent.change(iconInput, { target: { value: "→" } });
+    expect(iconInput.value).toBe("→");
   });
 });

--- a/src/settings/__tests__/TabEditor.test.tsx
+++ b/src/settings/__tests__/TabEditor.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { I18nextProvider } from "react-i18next";
+import type { ComponentProps } from "react";
+import { createI18n } from "../../core/i18n";
+import { TabEditor } from "../TabEditor";
+import type { Tab } from "../../core/types/Tab";
+
+type Props = ComponentProps<typeof TabEditor>;
+
+async function renderEditor(overrides: Partial<Props> = {}) {
+  const i18n = await createI18n("pt-BR");
+  const merged: Props = {
+    mode: "new",
+    initial: null,
+    onSave: vi.fn().mockResolvedValue(undefined),
+    onCancel: vi.fn(),
+    onDelete: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  const utils = render(
+    <I18nextProvider i18n={i18n}>
+      <TabEditor {...merged} />
+    </I18nextProvider>,
+  );
+  return { ...utils, props: merged };
+}
+
+const existing: Tab = {
+  id: "11111111-1111-1111-1111-111111111111",
+  name: "Trabalho",
+  icon: "💼",
+  order: 0,
+  openMode: "reuseOrNewWindow",
+  items: [{ kind: "url", value: "https://example.com" }],
+};
+
+describe("TabEditor", () => {
+  it("requires name or icon", async () => {
+    const user = userEvent.setup();
+    const { props } = await renderEditor();
+    await user.type(screen.getByLabelText(/url 1/i), "https://ok.test");
+    await user.click(screen.getByRole("button", { name: /^salvar$/i }));
+    expect(screen.getByText(/preencha nome ou ícone/i)).toBeTruthy();
+    expect(props.onSave).not.toHaveBeenCalled();
+  });
+
+  it("requires at least one URL", async () => {
+    const user = userEvent.setup();
+    const { props } = await renderEditor();
+    await user.type(screen.getByLabelText(/nome/i), "A");
+    await user.click(screen.getByRole("button", { name: /remover url/i }));
+    await user.click(screen.getByRole("button", { name: /^salvar$/i }));
+    expect(screen.getByText(/adicione ao menos uma url/i)).toBeTruthy();
+    expect(props.onSave).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed URLs client-side", async () => {
+    const user = userEvent.setup();
+    const { props } = await renderEditor();
+    await user.type(screen.getByLabelText(/nome/i), "A");
+    await user.type(screen.getByLabelText(/url 1/i), "not a url");
+    await user.click(screen.getByRole("button", { name: /^salvar$/i }));
+    expect(screen.getByText(/url inválida/i)).toBeTruthy();
+    expect(props.onSave).not.toHaveBeenCalled();
+  });
+
+  it("saves a valid new tab with only-icon", async () => {
+    const user = userEvent.setup();
+    const { props } = await renderEditor();
+    await user.type(screen.getByLabelText(/ícone/i), "📝");
+    await user.type(screen.getByLabelText(/url 1/i), "https://a.test");
+    await user.click(screen.getByRole("button", { name: /^salvar$/i }));
+    expect(props.onSave).toHaveBeenCalledTimes(1);
+    const payload = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as Tab;
+    expect(payload.icon).toBe("📝");
+    expect(payload.name).toBeNull();
+    expect(payload.items).toHaveLength(1);
+  });
+
+  it("prefills fields when editing an existing tab", async () => {
+    await renderEditor({ mode: "edit", initial: existing });
+    expect((screen.getByLabelText(/nome/i) as HTMLInputElement).value).toBe("Trabalho");
+    expect((screen.getByLabelText(/ícone/i) as HTMLInputElement).value).toBe("💼");
+    expect((screen.getByLabelText(/url 1/i) as HTMLInputElement).value).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("delete is only shown in edit mode and calls onDelete after confirm", async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    try {
+      const { props } = await renderEditor({ mode: "edit", initial: existing });
+      await user.click(screen.getByRole("button", { name: /^excluir$/i }));
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(props.onDelete).toHaveBeenCalledWith(existing.id);
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+
+  it("does not render delete in new mode", async () => {
+    await renderEditor({ mode: "new" });
+    expect(screen.queryByRole("button", { name: /^excluir$/i })).toBeNull();
+  });
+});

--- a/src/settings/__tests__/TabList.test.tsx
+++ b/src/settings/__tests__/TabList.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { I18nextProvider } from "react-i18next";
+import { createI18n } from "../../core/i18n";
+import { TabList } from "../TabList";
+import type { Tab } from "../../core/types/Tab";
+import type { ReactElement } from "react";
+
+async function renderWithI18n(ui: ReactElement) {
+  const i18n = await createI18n("pt-BR");
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>);
+}
+
+const tab = (id: string, name: string, order: number): Tab => ({
+  id,
+  name,
+  icon: null,
+  order,
+  openMode: "reuseOrNewWindow",
+  items: [],
+});
+
+describe("TabList", () => {
+  it("renders empty state when there are no tabs", async () => {
+    await renderWithI18n(
+      <TabList tabs={[]} selectedId={null} onSelect={() => {}} onAdd={() => {}} />,
+    );
+    expect(screen.getByText(/nenhuma aba cadastrada/i)).toBeTruthy();
+  });
+
+  it("renders tabs sorted by order and highlights the selected one", async () => {
+    const t0 = tab("a", "A", 1);
+    const t1 = tab("b", "B", 0);
+    await renderWithI18n(
+      <TabList tabs={[t0, t1]} selectedId="a" onSelect={() => {}} onAdd={() => {}} />,
+    );
+    const rows = screen
+      .getAllByRole("button")
+      .filter((b) => b.getAttribute("data-testid") === "tab-row");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].textContent).toContain("B");
+    expect(rows[1].textContent).toContain("A");
+    expect(rows[1].getAttribute("data-selected")).toBe("true");
+  });
+
+  it("calls onSelect with the tab id on click", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    await renderWithI18n(
+      <TabList
+        tabs={[tab("a", "A", 0)]}
+        selectedId={null}
+        onSelect={onSelect}
+        onAdd={() => {}}
+      />,
+    );
+    await user.click(screen.getByText("A"));
+    expect(onSelect).toHaveBeenCalledWith("a");
+  });
+
+  it("calls onAdd when clicking the add button", async () => {
+    const user = userEvent.setup();
+    const onAdd = vi.fn();
+    await renderWithI18n(
+      <TabList tabs={[]} selectedId={null} onSelect={() => {}} onAdd={onAdd} />,
+    );
+    await user.click(screen.getByRole("button", { name: /adicionar aba/i }));
+    expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/settings/__tests__/useConfig.test.tsx
+++ b/src/settings/__tests__/useConfig.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useConfig } from "../useConfig";
+
+type Listener = (e: { payload: unknown }) => void;
+
+vi.mock("@tauri-apps/api/event", () => {
+  const listeners = new Map<string, Set<Listener>>();
+  return {
+    listen: vi.fn(async (name: string, cb: Listener) => {
+      const set = listeners.get(name) ?? new Set<Listener>();
+      set.add(cb);
+      listeners.set(name, set);
+      return () => {
+        set.delete(cb);
+      };
+    }),
+    __emit: (name: string, payload: unknown) => {
+      listeners.get(name)?.forEach((cb) => cb({ payload }));
+    },
+  };
+});
+
+vi.mock("../../core/ipc", () => ({
+  ipc: {
+    getConfig: vi.fn(),
+    saveTab: vi.fn(),
+    deleteTab: vi.fn(),
+    openSettings: vi.fn(),
+    closeSettings: vi.fn(),
+    openTab: vi.fn(),
+    hideDonut: vi.fn(),
+  },
+  CONFIG_CHANGED_EVENT: "config-changed",
+}));
+
+import { ipc } from "../../core/ipc";
+import * as events from "@tauri-apps/api/event";
+
+const makeConfig = (overrides: Partial<{ tabs: unknown[] }> = {}) => ({
+  version: 1,
+  shortcut: "CommandOrControl+Shift+Space",
+  appearance: { theme: "dark", language: "auto" },
+  interaction: {
+    spawnPosition: "cursor",
+    selectionMode: "clickOrRelease",
+    hoverHoldMs: 800,
+  },
+  pagination: { itemsPerPage: 6, wheelDirection: "standard" },
+  system: { autostart: false },
+  tabs: [],
+  ...overrides,
+});
+
+describe("useConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads config on mount", async () => {
+    const cfg = makeConfig();
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(cfg);
+    const { result } = renderHook(() => useConfig());
+    await waitFor(() => expect(result.current.config).toEqual(cfg));
+  });
+
+  it("applies config-changed event updates", async () => {
+    const initial = makeConfig();
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(initial);
+    const { result } = renderHook(() => useConfig());
+    await waitFor(() => expect(result.current.config).toEqual(initial));
+
+    const updated = makeConfig({ tabs: [{ id: "x" } as unknown] });
+    act(() => {
+      (events as unknown as { __emit: (n: string, p: unknown) => void }).__emit(
+        "config-changed",
+        updated,
+      );
+    });
+    await waitFor(() => expect(result.current.config).toEqual(updated));
+  });
+
+  it("saveTab delegates to ipc and returns the new config", async () => {
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(makeConfig());
+    const updated = makeConfig({ tabs: [{ id: "n" } as unknown] });
+    (ipc.saveTab as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+
+    const { result } = renderHook(() => useConfig());
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+
+    const tab = {
+      id: "n",
+      name: "N",
+      icon: null,
+      order: 0,
+      openMode: "newTab",
+      items: [],
+    } as never;
+    const returned = await act(() => result.current.saveTab(tab));
+    expect(returned).toEqual(updated);
+    expect(ipc.saveTab).toHaveBeenCalledWith(tab);
+  });
+
+  it("deleteTab delegates to ipc", async () => {
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(makeConfig());
+    const updated = makeConfig();
+    (ipc.deleteTab as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+
+    const { result } = renderHook(() => useConfig());
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+
+    await act(() => result.current.deleteTab("some-id"));
+    expect(ipc.deleteTab).toHaveBeenCalledWith("some-id");
+  });
+});

--- a/src/settings/__tests__/useConfig.test.tsx
+++ b/src/settings/__tests__/useConfig.test.tsx
@@ -18,6 +18,9 @@ vi.mock("@tauri-apps/api/event", () => {
     __emit: (name: string, payload: unknown) => {
       listeners.get(name)?.forEach((cb) => cb({ payload }));
     },
+    __reset: () => {
+      listeners.clear();
+    },
   };
 });
 
@@ -57,6 +60,7 @@ const makeConfig = (overrides: Partial<{ tabs: unknown[] }> = {}) => ({
 describe("useConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (events as unknown as { __reset: () => void }).__reset();
   });
 
   it("loads config on mount", async () => {

--- a/src/settings/__tests__/useConfig.test.tsx
+++ b/src/settings/__tests__/useConfig.test.tsx
@@ -30,8 +30,10 @@ vi.mock("../../core/ipc", () => ({
     closeSettings: vi.fn(),
     openTab: vi.fn(),
     hideDonut: vi.fn(),
+    consumeSettingsIntent: vi.fn().mockResolvedValue(null),
   },
   CONFIG_CHANGED_EVENT: "config-changed",
+  SETTINGS_INTENT_EVENT: "settings-intent",
 }));
 
 import { ipc } from "../../core/ipc";

--- a/src/settings/useConfig.ts
+++ b/src/settings/useConfig.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState, useCallback } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { ipc, CONFIG_CHANGED_EVENT } from "../core/ipc";
+import type { Config } from "../core/types/Config";
+import type { Tab } from "../core/types/Tab";
+
+export interface UseConfig {
+  config: Config | null;
+  loadError: unknown;
+  saveTab: (tab: Tab) => Promise<Config>;
+  deleteTab: (tabId: string) => Promise<Config>;
+}
+
+export function useConfig(): UseConfig {
+  const [config, setConfig] = useState<Config | null>(null);
+  const [loadError, setLoadError] = useState<unknown>(null);
+
+  useEffect(() => {
+    let disposed = false;
+    ipc
+      .getConfig()
+      .then((c) => {
+        if (!disposed) setConfig(c);
+      })
+      .catch((e) => {
+        if (!disposed) setLoadError(e);
+      });
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    void listen<Config>(CONFIG_CHANGED_EVENT, (e) => {
+      setConfig(e.payload);
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  const saveTab = useCallback(async (tab: Tab) => {
+    const next = await ipc.saveTab(tab);
+    setConfig(next);
+    return next;
+  }, []);
+
+  const deleteTab = useCallback(async (tabId: string) => {
+    const next = await ipc.deleteTab(tabId);
+    setConfig(next);
+    return next;
+  }, []);
+
+  return { config, loadError, saveTab, deleteTab };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         donut: resolve(__dirname, "donut.html"),
+        settings: resolve(__dirname, "settings.html"),
       },
     },
   },


### PR DESCRIPTION
Implementa o Plano 3 (Settings CRUD) conforme [docs/plans/03-settings-crud.md](docs/plans/03-settings-crud.md), com vários ajustes de polimento descobertos durante o QA.

## Summary

- Nova janela **Settings** decorada (multi-entry Vite) com `TabList`, `TabEditor`, `UrlListEditor` e `SettingsApp`.
- **Rust**: comandos `save_tab` / `delete_tab` / `open_settings` / `consume_settings_intent` / `close_settings`. Write atômica em `config::io::save_atomic` (escreve `.tmp` → `rename`, valida antes). Evento `config-changed` emitido em toda mutação bem-sucedida; rollback em memória se o IO falhar.
- **Tray** ganha "Configurações".
- **Engrenagem ⚙** do donut passa a abrir Settings; donut escuta `config-changed` e sincroniza em tempo real.
- Fatia **"+"** no donut abre Settings direto no editor de nova aba (intent routing via evento Tauri + buffer em `AppState` para evitar race na primeira abertura). Corrige também o bug visual do arco degenerado quando há apenas uma fatia: 0 abas → anel completo via dois sub-paths + `fill-rule="evenodd"`.
- Hook `useConfig` como fonte única da verdade para a Settings: carrega via `get_config`, escuta `config-changed`, expõe `saveTab`/`deleteTab`.

## QA fixes

- **WebView2 prewarm**: a Settings é criada no `setup()` do Tauri. Sem isso, `WebviewWindowBuilder::build()` para janela decorada travava silenciosamente no Windows quando invocado tardiamente de um comando.
- **`hide` em vez de `close`** em `close_settings`: preserva a webview pré-aquecida entre aberturas.
- **Startup tolerante a falha de atalho / prewarm**: log + continua em vez de panic, alinhado com `Plano.md` 6.1. Caso típico: HMR de Rust deixando o atalho preso no processo antigo.
- **Campo de ícone restringido**: `maxLength={16}`, `size={4}`, filtro `\p{L}` no `onChange` (letras não chegam a aparecer) e validação de 1 grafema via `Intl.Segmenter` no save (cobre emojis compostos como 🇧🇷 e 👨‍👩‍👧).
- **Seletor de `openMode` escondido**: não existe API do SO (`ShellExecute` / `xdg-open` / `open`) que honre "nova aba vs nova janela" — decisão é do navegador. Campo permanece no schema; implementação real vai para Fase 3 (`Plano.md` 8.3: "openMode por item: navegador específico por URL").
- **Erros de `openSettings` localizados**: falhas surgem via `translateAppError` como toast no donut em vez de serem engolidas pelo `finally`.
- **Mock de `listen` resetado entre testes** para evitar callbacks de componentes desmontados disparando em casos posteriores.
- **`.gitattributes`**: força LF em todo arquivo texto, eliminando os falsos "modified" causados por `core.autocrlf=true` no Windows + ferramentas (cargo, tauri-build, ts-rs, Vite) que escrevem LF.

## Test plan

- [x] `cargo test --lib` — 49 testes (schema, validate, io atômica, launcher, errors, commands com `apply_save`/`apply_delete`).
- [x] `npm test` — 57 testes (useConfig, TabList, TabEditor, UrlListEditor, SettingsApp intent-routing, Donut, geometry, i18n, errors).
- [x] `npx tsc --noEmit`.
- [x] `cargo fmt --check` e `cargo clippy --lib` limpos.
- [x] Smoke manual: tray → Configurações; criar, editar, excluir aba; donut reflete em tempo real; fatia "+" abre direto em "Nova aba"; campo de ícone rejeita letras, aceita emojis compostos.

## Out of scope (planos seguintes)

- `<ShortcutRecorder>` e `<AppearanceSection>` com seletor de idioma — **Plano 4**.
- Paginação, hover-hold editar/excluir na fatia — **Plano 5**.
- Perfis (schema v2) — **Plano 6**.
- `openMode` real via flags específicas do navegador, menu de contexto, favicons, drag-and-drop, autostart — **Plano 7** / **Fase 3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
