### PR TITLE
fix(settings): tolerar Tab.children ausente no payload IPC

### DIFF
--- a/src/donut/Donut.tsx
+++ b/src/donut/Donut.tsx
@@ -32,8 +32,12 @@ function firstTabUrl(tab: Tab): string | null {
 
 /** Conta total de descendentes (children + grandchildren ...). */
 export function countDescendants(tab: Tab): number {
+  // Backend serializa `children` com `skip_serializing_if = "Vec::is_empty"`,
+  // então leaves chegam aqui com `children === undefined` mesmo sendo `Tab[]`
+  // no tipo ts-rs. `?? []` protege a iteração.
+  const kids = tab.children ?? [];
   let n = 0;
-  for (const c of tab.children) {
+  for (const c of kids) {
     n += 1 + countDescendants(c);
   }
   return n;
@@ -538,7 +542,7 @@ function labelForPathSegment(
     const found = current.find((t) => t.id === id);
     if (!found) return targetId;
     if (id === targetId) return found.name ?? found.icon ?? targetId;
-    current = found.children;
+    current = found.children ?? [];
   }
   return targetId;
 }

--- a/src/donut/findTab.ts
+++ b/src/donut/findTab.ts
@@ -28,7 +28,10 @@ export function findTabByPath(
     if (!next || next.kind !== "group") {
       return { tabs: [], valid: false };
     }
-    current = next.children;
+    // Backend elide `children` quando vazio (`Vec::is_empty` skip),
+    // então um group vazio chega com `children === undefined` mesmo
+    // o tipo ts-rs dizendo `Tab[]`. `?? []` mantém a iteração segura.
+    current = next.children ?? [];
   }
   return { tabs: current, valid: true };
 }

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -34,10 +34,11 @@ interface IntentTarget {
  * (lista de ids dos pais) e o tab encontrado, ou `null` se não bater.
  */
 function findTabPathInProfile(
-  tabs: Tab[],
+  tabs: Tab[] | undefined,
   targetId: string,
   acc: string[] = [],
 ): { tab: Tab; path: string[] } | null {
+  if (!tabs) return null;
   for (const tab of tabs) {
     if (tab.id === targetId) return { tab, path: acc };
     const inner = findTabPathInProfile(tab.children, targetId, [...acc, tab.id]);

--- a/src/settings/__tests__/SettingsApp.test.tsx
+++ b/src/settings/__tests__/SettingsApp.test.tsx
@@ -218,6 +218,48 @@ describe("SettingsApp intent routing", () => {
     expect(screen.queryByRole("heading", { name: /nova aba/i })).toBeNull();
   });
 
+  it("clicking a tab when sibling leaves lack the `children` field doesn't crash", async () => {
+    // Backend serializa `Tab.children` com `skip_serializing_if = "Vec::is_empty"`,
+    // então leaves chegam ao frontend sem o campo. `findTabPathInProfile`
+    // recursivo precisa tolerar `tab.children === undefined`. Regressão real
+    // observada no app: clicar numa aba após o primeiro irmão quebrava o
+    // render porque `for (const t of undefined)` lançava `TypeError`.
+    const cfg = makeConfig({
+      profiles: [
+        makeProfile({
+          tabs: [
+            {
+              id: "first",
+              name: "Primeiro",
+              icon: null,
+              order: 0,
+              openMode: "reuseOrNewWindow",
+              items: [{ kind: "url", value: "https://a.test" }],
+              // sem `children` — simula o JSON real do backend
+            } as never,
+            {
+              id: "second",
+              name: "Segundo",
+              icon: null,
+              order: 1,
+              openMode: "reuseOrNewWindow",
+              items: [{ kind: "url", value: "https://b.test" }],
+            } as never,
+          ],
+        }),
+      ],
+    });
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(cfg);
+    (ipc.consumeSettingsIntent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "edit-tab:second",
+    );
+    await renderApp();
+    await waitFor(() => {
+      const nameInput = screen.getByLabelText(/nome/i) as HTMLInputElement;
+      expect(nameInput.value).toBe("Segundo");
+    });
+  });
+
   it("ignores 'edit-tab:<id>' when the tab id does not exist", async () => {
     (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(makeConfig());
     (ipc.consumeSettingsIntent as ReturnType<typeof vi.fn>).mockResolvedValue(


### PR DESCRIPTION
Backend serializa `Tab.children` com `skip_serializing_if = "Vec::is_empty"`, então leaves chegam ao frontend sem o campo apesar do tipo ts-rs declarar `Array<Tab>`. `findTabPathInProfile` recursava `for (const tab of undefined)` quando havia leaves siblings antes da aba alvo, lançando `TypeError: tabs is not iterable` e apagando a tela de Configurações.

Guarda `?? []` em todos os consumers que iteram `tab.children` (`findTabPathInProfile`, `countDescendants`, `labelForPathSegment`, `findTabByPath`) + teste de regressão cobrindo recursão sobre sibling leaf sem `children` no JSON.