### PR TITLE
Fix/issues batch 2

### DIFF
--- a/src-tauri/src/config/schema.rs
+++ b/src-tauri/src/config/schema.rs
@@ -327,7 +327,7 @@ impl Default for Config {
             interaction: Interaction {
                 spawn_position: SpawnPosition::Cursor,
                 selection_mode: SelectionMode::ClickOrRelease,
-                hover_hold_ms: 800,
+                hover_hold_ms: 1200,
                 search_shortcut: default_search_shortcut(),
             },
             pagination: Pagination {

--- a/src/donut/Donut.tsx
+++ b/src/donut/Donut.tsx
@@ -130,7 +130,7 @@ export const Donut: React.FC<DonutProps> = ({
   size,
   itemsPerPage,
   wheelDirection,
-  hoverHoldMs = 800,
+  hoverHoldMs = 1200,
   searchShortcut,
   tokens,
   onSelect,

--- a/src/donut/HoverHoldOverlay.tsx
+++ b/src/donut/HoverHoldOverlay.tsx
@@ -49,7 +49,7 @@ export const HoverHoldOverlay: React.FC<HoverHoldOverlayProps> = ({
     });
     return (
       <g data-testid="hover-hold-fill" pointerEvents="none">
-        <path d={d} fill="rgba(80, 130, 220, 0.45)" />
+        <path d={d} fill="rgba(80, 130, 220, 0.25)" />
       </g>
     );
   }
@@ -96,7 +96,7 @@ export const HoverHoldOverlay: React.FC<HoverHoldOverlayProps> = ({
           role="button"
           tabIndex={0}
           aria-label={t("donut.hoverHold.edit")}
-          fill="rgba(80, 130, 220, 0.55)"
+          fill="rgba(80, 130, 220, 0.35)"
           style={{ cursor: "pointer", outline: "none" }}
           onClick={(e) => {
             e.stopPropagation();
@@ -110,7 +110,7 @@ export const HoverHoldOverlay: React.FC<HoverHoldOverlayProps> = ({
           role="button"
           tabIndex={0}
           aria-label={t("donut.hoverHold.delete")}
-          fill="rgba(200, 60, 60, 0.55)"
+          fill="rgba(200, 60, 60, 0.35)"
           style={{ cursor: "pointer", outline: "none" }}
           onClick={(e) => {
             e.stopPropagation();

--- a/src/entry/donut.tsx
+++ b/src/entry/donut.tsx
@@ -28,6 +28,10 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [scriptPrompt, setScriptPrompt] = useState<ScriptPrompt | null>(null);
   const [tokens, setTokens] = useState<ThemeTokens | undefined>(undefined);
+  // Bumpa a cada re-show pra remontar o <Donut> e zerar estado local
+  // (mode profile-switcher, sub-donut navigation, hover-hold). Reabrir o
+  // donut sempre começa em "tabs" no root.
+  const [showKey, setShowKey] = useState(0);
 
   useEffect(() => {
     if (config) return;
@@ -65,6 +69,9 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
         requestAnimationFrame(() =>
           requestAnimationFrame(() => html.classList.add("donut-visible")),
         );
+        // Bumpa a key pra remontar o <Donut> e descartar estado local
+        // residual da sessão anterior (issue #13).
+        setShowKey((k) => k + 1);
       } else {
         // Limpa a class antes do hide pra que o próximo show comece em
         // opacity 0 (sem isso, próxima abertura aparece sem fade).
@@ -219,6 +226,7 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
             config.profiles.find((p) => p.id === config.activeProfileId) ?? null;
           return (
             <Donut
+              key={showKey}
               tabs={activeProfile?.tabs ?? []}
               size={WINDOW_SIZE}
               itemsPerPage={config.pagination.itemsPerPage}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -106,6 +106,7 @@
       "tabs": "Tabs",
       "appearance": "Appearance",
       "shortcut": "Shortcut",
+      "system": "System",
       "history": "History"
     },
     "profile": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -106,6 +106,7 @@
       "tabs": "Abas",
       "appearance": "Aparência",
       "shortcut": "Atalho",
+      "system": "Sistema",
       "history": "Histórico"
     },
     "profile": {

--- a/src/settings/AppearanceSection.tsx
+++ b/src/settings/AppearanceSection.tsx
@@ -1,36 +1,17 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import type { Theme } from "../core/types/Theme";
-import type { Language } from "../core/types/Language";
 import type { ThemeOverrides } from "../core/types/ThemeOverrides";
 import { ThemeCustomizer } from "./ThemeCustomizer";
-import { UpdateCard } from "./UpdateCard";
 
 export interface AppearanceSectionProps {
   theme: Theme;
-  language: Language;
-  autostart: boolean;
   onThemeChange: (theme: Theme) => void;
-  onLanguageChange: (language: Language) => void;
-  onAutostartChange: (enabled: boolean) => void;
-  /** Backup do config.json para um arquivo arbitrário escolhido pelo user. */
-  onExportConfig?: () => void;
-  /** Substitui o config inteiro por um JSON externo. */
-  onImportConfig?: () => void;
   /** Quando o perfil sob edição não é o ativo, mostra um botão pra ativá-lo. */
   onSetActiveProfile?: () => void;
-  /** Plano 14: kill-switch global de scripts no perfil ativo. */
-  allowScripts?: boolean;
-  onAllowScriptsChange?: (allow: boolean) => void;
   /** Plano 15: overrides cosméticos do perfil em edição. */
   themeOverrides?: ThemeOverrides | null;
   onThemeOverridesChange?: (overrides: ThemeOverrides | null) => void;
-  /** Plano 18: toggle global do check de update no startup. */
-  autoCheckUpdates?: boolean;
-  onAutoCheckUpdatesChange?: (enabled: boolean) => void;
-  /** Plano 19: toggle global da captura de output de scripts. */
-  scriptHistoryEnabled?: boolean;
-  onScriptHistoryEnabledChange?: (enabled: boolean) => void;
 }
 
 const THEMES: Theme[] = ["dark", "light", "auto"];
@@ -42,22 +23,10 @@ const THEME_KEY: Record<Theme, string> = {
 
 export const AppearanceSection: React.FC<AppearanceSectionProps> = ({
   theme,
-  language,
-  autostart,
   onThemeChange,
-  onLanguageChange,
-  onAutostartChange,
-  onExportConfig,
-  onImportConfig,
   onSetActiveProfile,
-  allowScripts,
-  onAllowScriptsChange,
   themeOverrides,
   onThemeOverridesChange,
-  autoCheckUpdates,
-  onAutoCheckUpdatesChange,
-  scriptHistoryEnabled,
-  onScriptHistoryEnabledChange,
 }) => {
   const { t } = useTranslation();
 
@@ -101,182 +70,6 @@ export const AppearanceSection: React.FC<AppearanceSectionProps> = ({
           onOverridesChange={onThemeOverridesChange}
         />
       )}
-
-      <label
-        style={{ display: "flex", flexDirection: "column", gap: 4, maxWidth: 320 }}
-      >
-        <span>{t("settings.appearance.language")}</span>
-        <select
-          value={language}
-          onChange={(e) => onLanguageChange(e.target.value as Language)}
-          style={{
-            background: "var(--input-bg)",
-            color: "var(--fg)",
-            border: "1px solid var(--input-border)",
-            borderRadius: 4,
-            padding: "6px 8px",
-            font: "inherit",
-          }}
-        >
-          <option value="auto">{t("settings.appearance.languageAuto")}</option>
-          <option value="ptBr">{t("settings.appearance.languagePtBr")}</option>
-          <option value="en">{t("settings.appearance.languageEn")}</option>
-        </select>
-      </label>
-
-      <fieldset
-        style={{ border: "1px solid var(--input-border)", borderRadius: 4, padding: 12 }}
-      >
-        <legend style={{ padding: "0 6px" }}>{t("settings.system.title")}</legend>
-        <label
-          style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
-        >
-          <input
-            type="checkbox"
-            data-testid="autostart-toggle"
-            checked={autostart}
-            onChange={(e) => onAutostartChange(e.target.checked)}
-          />
-          {t("settings.system.autostart")}
-        </label>
-        <small style={{ color: "var(--muted)", display: "block", paddingLeft: 26 }}>
-          {t("settings.system.autostartHint")}
-        </small>
-
-        {allowScripts !== undefined && onAllowScriptsChange && (
-          <div
-            style={{
-              marginTop: 12,
-              paddingTop: 12,
-              borderTop: "1px solid var(--input-border)",
-            }}
-          >
-            <label
-              style={{
-                display: "flex",
-                gap: 6,
-                alignItems: "center",
-                padding: 4,
-              }}
-            >
-              <input
-                type="checkbox"
-                data-testid="allow-scripts-toggle"
-                checked={allowScripts}
-                onChange={(e) => onAllowScriptsChange(e.target.checked)}
-              />
-              {t("settings.system.allowScriptsLabel")}
-            </label>
-            <small
-              style={{
-                color: "var(--muted)",
-                display: "block",
-                paddingLeft: 26,
-              }}
-            >
-              {t("settings.system.allowScriptsHint")}
-            </small>
-          </div>
-        )}
-
-        {autoCheckUpdates !== undefined && onAutoCheckUpdatesChange && (
-          <UpdateCard
-            autoCheckUpdates={autoCheckUpdates}
-            onAutoCheckUpdatesChange={onAutoCheckUpdatesChange}
-          />
-        )}
-
-        {scriptHistoryEnabled !== undefined && onScriptHistoryEnabledChange && (
-          <div
-            style={{
-              marginTop: 12,
-              paddingTop: 12,
-              borderTop: "1px solid var(--input-border)",
-            }}
-          >
-            <label
-              style={{
-                display: "flex",
-                gap: 6,
-                alignItems: "center",
-                padding: 4,
-              }}
-            >
-              <input
-                type="checkbox"
-                data-testid="script-history-toggle"
-                checked={scriptHistoryEnabled}
-                onChange={(e) => onScriptHistoryEnabledChange(e.target.checked)}
-              />
-              {t("settings.system.scriptHistoryLabel")}
-            </label>
-            <small
-              style={{
-                color: "var(--muted)",
-                display: "block",
-                paddingLeft: 26,
-              }}
-            >
-              {t("settings.system.scriptHistoryHint")}
-            </small>
-          </div>
-        )}
-
-        {(onExportConfig || onImportConfig) && (
-          <div
-            style={{
-              marginTop: 12,
-              paddingTop: 12,
-              borderTop: "1px solid var(--input-border)",
-              display: "flex",
-              flexDirection: "column",
-              gap: 6,
-            }}
-          >
-            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-              {onExportConfig && (
-                <button
-                  type="button"
-                  data-testid="export-config"
-                  onClick={onExportConfig}
-                  style={{
-                    background: "transparent",
-                    color: "var(--fg)",
-                    border: "1px solid var(--ghost-border)",
-                    borderRadius: 4,
-                    padding: "6px 12px",
-                    cursor: "pointer",
-                    font: "inherit",
-                  }}
-                >
-                  {t("settings.system.exportButton")}
-                </button>
-              )}
-              {onImportConfig && (
-                <button
-                  type="button"
-                  data-testid="import-config"
-                  onClick={onImportConfig}
-                  style={{
-                    background: "transparent",
-                    color: "var(--fg)",
-                    border: "1px solid var(--ghost-border)",
-                    borderRadius: 4,
-                    padding: "6px 12px",
-                    cursor: "pointer",
-                    font: "inherit",
-                  }}
-                >
-                  {t("settings.system.importButton")}
-                </button>
-              )}
-            </div>
-            <small style={{ color: "var(--muted)" }}>
-              {t("settings.system.exportImportHint")}
-            </small>
-          </div>
-        )}
-      </fieldset>
 
       {onSetActiveProfile && (
         <button

--- a/src/settings/SectionTabs.tsx
+++ b/src/settings/SectionTabs.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-export type Section = "tabs" | "appearance" | "shortcut" | "history";
+export type Section = "tabs" | "appearance" | "shortcut" | "system" | "history";
 
-const SECTIONS: Section[] = ["tabs", "appearance", "shortcut", "history"];
+const SECTIONS: Section[] = ["tabs", "appearance", "shortcut", "system", "history"];
 
 export interface SectionTabsProps {
   active: Section;

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -5,6 +5,7 @@ import { TabList } from "./TabList";
 import { TabEditor } from "./TabEditor";
 import { AppearanceSection } from "./AppearanceSection";
 import { ShortcutSection } from "./ShortcutSection";
+import { SystemSection } from "./SystemSection";
 import { HistorySection } from "./HistorySection";
 import { SectionTabs, type Section } from "./SectionTabs";
 import { ProfilePicker } from "./ProfilePicker";
@@ -396,14 +397,30 @@ export const SettingsApp: React.FC = () => {
       {section === "appearance" && (
         <AppearanceSection
           theme={selectedProfile.theme}
-          language={config.appearance.language}
-          autostart={config.system.autostart}
           onThemeChange={(theme) => {
             void setTheme(theme, selectedProfile.id);
           }}
+          onSetActiveProfile={
+            selectedProfile.id !== config.activeProfileId
+              ? () => {
+                  void setActiveProfile(selectedProfile.id);
+                }
+              : undefined
+          }
+          themeOverrides={selectedProfile.themeOverrides}
+          onThemeOverridesChange={(overrides) => {
+            void setProfileThemeOverrides(selectedProfile.id, overrides);
+          }}
+        />
+      )}
+
+      {section === "system" && (
+        <SystemSection
+          language={config.appearance.language}
           onLanguageChange={(language) => {
             void setLanguage(language);
           }}
+          autostart={config.system.autostart}
           onAutostartChange={(enabled) => {
             void setAutostart(enabled);
           }}
@@ -443,20 +460,9 @@ export const SettingsApp: React.FC = () => {
               }
             })();
           }}
-          onSetActiveProfile={
-            selectedProfile.id !== config.activeProfileId
-              ? () => {
-                  void setActiveProfile(selectedProfile.id);
-                }
-              : undefined
-          }
           allowScripts={selectedProfile.allowScripts}
           onAllowScriptsChange={(allow) => {
             void setProfileAllowScripts(selectedProfile.id, allow);
-          }}
-          themeOverrides={selectedProfile.themeOverrides}
-          onThemeOverridesChange={(overrides) => {
-            void setProfileThemeOverrides(selectedProfile.id, overrides);
           }}
           autoCheckUpdates={config.system.autoCheckUpdates}
           onAutoCheckUpdatesChange={(enabled) => {

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -61,7 +61,14 @@ function resolveIntent(
   config: Config | null,
 ): IntentTarget | null {
   if (intent === "new-tab") {
-    return { section: "tabs", selection: { mode: "new" } };
+    // O "+" do donut sempre refere ao perfil ativo. Forçar o
+    // selectedProfileId aqui evita que o Settings reaproveite o perfil
+    // selecionado de uma sessão anterior (issue #23).
+    return {
+      section: "tabs",
+      selection: { mode: "new" },
+      selectedProfileId: config?.activeProfileId,
+    };
   }
   if (intent === "new-profile") {
     return {
@@ -76,6 +83,7 @@ function resolveIntent(
     return {
       section: "tabs",
       selection: { mode: "new", parentPath },
+      selectedProfileId: config?.activeProfileId,
     };
   }
   if (intent && intent.startsWith("edit-tab:")) {
@@ -145,11 +153,16 @@ export const SettingsApp: React.FC = () => {
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     const handle = (intent: string | null) => {
-      // Intents que dependem do config (lookup de aba/perfil) ou que abrem
-      // prompt na UI (new-profile) ficam em buffer até o config carregar.
+      // Intents que dependem do config (lookup de aba/perfil, resolução do
+      // perfil ativo) ou que abrem prompt na UI (new-profile) ficam em
+      // buffer até o config carregar. `new-tab` e `new-tab-in-group:`
+      // precisam do config pra resolver `activeProfileId` (issue #23).
       const needsConfig =
         !!intent &&
-        (intent.startsWith("edit-tab:") || intent === "new-profile");
+        (intent.startsWith("edit-tab:") ||
+          intent === "new-profile" ||
+          intent === "new-tab" ||
+          intent.startsWith("new-tab-in-group:"));
       if (needsConfig && !configRef.current) {
         pendingIntentRef.current = intent;
         return;

--- a/src/settings/SystemSection.tsx
+++ b/src/settings/SystemSection.tsx
@@ -1,0 +1,186 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import type { Language } from "../core/types/Language";
+import { UpdateCard } from "./UpdateCard";
+
+export interface SystemSectionProps {
+  language: Language;
+  onLanguageChange: (language: Language) => void;
+  autostart: boolean;
+  onAutostartChange: (enabled: boolean) => void;
+  /** Backup do config.json para um arquivo arbitrário escolhido pelo user. */
+  onExportConfig?: () => void;
+  /** Substitui o config inteiro por um JSON externo. */
+  onImportConfig?: () => void;
+  /** Plano 14: kill-switch global de scripts no perfil em edição. */
+  allowScripts?: boolean;
+  onAllowScriptsChange?: (allow: boolean) => void;
+  /** Plano 18: toggle global do check de update no startup. */
+  autoCheckUpdates?: boolean;
+  onAutoCheckUpdatesChange?: (enabled: boolean) => void;
+  /** Plano 19: toggle global da captura de output de scripts. */
+  scriptHistoryEnabled?: boolean;
+  onScriptHistoryEnabledChange?: (enabled: boolean) => void;
+}
+
+export const SystemSection: React.FC<SystemSectionProps> = ({
+  language,
+  onLanguageChange,
+  autostart,
+  onAutostartChange,
+  onExportConfig,
+  onImportConfig,
+  allowScripts,
+  onAllowScriptsChange,
+  autoCheckUpdates,
+  onAutoCheckUpdatesChange,
+  scriptHistoryEnabled,
+  onScriptHistoryEnabledChange,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <section
+      style={{
+        flex: 1,
+        padding: 24,
+        display: "flex",
+        flexDirection: "column",
+        gap: 24,
+        overflow: "auto",
+      }}
+    >
+      <h2 style={{ margin: 0 }}>{t("settings.sections.system")}</h2>
+
+      <label
+        style={{ display: "flex", flexDirection: "column", gap: 4, maxWidth: 320 }}
+      >
+        <span>{t("settings.appearance.language")}</span>
+        <select
+          value={language}
+          onChange={(e) => onLanguageChange(e.target.value as Language)}
+          style={{
+            background: "var(--input-bg)",
+            color: "var(--fg)",
+            border: "1px solid var(--input-border)",
+            borderRadius: 4,
+            padding: "6px 8px",
+            font: "inherit",
+          }}
+        >
+          <option value="auto">{t("settings.appearance.languageAuto")}</option>
+          <option value="ptBr">{t("settings.appearance.languagePtBr")}</option>
+          <option value="en">{t("settings.appearance.languageEn")}</option>
+        </select>
+      </label>
+
+      <div>
+        <label
+          style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
+        >
+          <input
+            type="checkbox"
+            data-testid="autostart-toggle"
+            checked={autostart}
+            onChange={(e) => onAutostartChange(e.target.checked)}
+          />
+          {t("settings.system.autostart")}
+        </label>
+        <small style={{ color: "var(--muted)", display: "block", paddingLeft: 26 }}>
+          {t("settings.system.autostartHint")}
+        </small>
+      </div>
+
+      {allowScripts !== undefined && onAllowScriptsChange && (
+        <div>
+          <label
+            style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
+          >
+            <input
+              type="checkbox"
+              data-testid="allow-scripts-toggle"
+              checked={allowScripts}
+              onChange={(e) => onAllowScriptsChange(e.target.checked)}
+            />
+            {t("settings.system.allowScriptsLabel")}
+          </label>
+          <small style={{ color: "var(--muted)", display: "block", paddingLeft: 26 }}>
+            {t("settings.system.allowScriptsHint")}
+          </small>
+        </div>
+      )}
+
+      {autoCheckUpdates !== undefined && onAutoCheckUpdatesChange && (
+        <UpdateCard
+          autoCheckUpdates={autoCheckUpdates}
+          onAutoCheckUpdatesChange={onAutoCheckUpdatesChange}
+        />
+      )}
+
+      {scriptHistoryEnabled !== undefined && onScriptHistoryEnabledChange && (
+        <div>
+          <label
+            style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
+          >
+            <input
+              type="checkbox"
+              data-testid="script-history-toggle"
+              checked={scriptHistoryEnabled}
+              onChange={(e) => onScriptHistoryEnabledChange(e.target.checked)}
+            />
+            {t("settings.system.scriptHistoryLabel")}
+          </label>
+          <small style={{ color: "var(--muted)", display: "block", paddingLeft: 26 }}>
+            {t("settings.system.scriptHistoryHint")}
+          </small>
+        </div>
+      )}
+
+      {(onExportConfig || onImportConfig) && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            {onExportConfig && (
+              <button
+                type="button"
+                data-testid="export-config"
+                onClick={onExportConfig}
+                style={{
+                  background: "transparent",
+                  color: "var(--fg)",
+                  border: "1px solid var(--ghost-border)",
+                  borderRadius: 4,
+                  padding: "6px 12px",
+                  cursor: "pointer",
+                  font: "inherit",
+                }}
+              >
+                {t("settings.system.exportButton")}
+              </button>
+            )}
+            {onImportConfig && (
+              <button
+                type="button"
+                data-testid="import-config"
+                onClick={onImportConfig}
+                style={{
+                  background: "transparent",
+                  color: "var(--fg)",
+                  border: "1px solid var(--ghost-border)",
+                  borderRadius: 4,
+                  padding: "6px 12px",
+                  cursor: "pointer",
+                  font: "inherit",
+                }}
+              >
+                {t("settings.system.importButton")}
+              </button>
+            )}
+          </div>
+          <small style={{ color: "var(--muted)" }}>
+            {t("settings.system.exportImportHint")}
+          </small>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/src/settings/__tests__/AppearanceSection.test.tsx
+++ b/src/settings/__tests__/AppearanceSection.test.tsx
@@ -5,27 +5,16 @@ import { I18nextProvider } from "react-i18next";
 import { createI18n } from "../../core/i18n";
 import { AppearanceSection } from "../AppearanceSection";
 import type { Theme } from "../../core/types/Theme";
-import type { Language } from "../../core/types/Language";
 
 async function renderSection(overrides: Partial<{
   theme: Theme;
-  language: Language;
-  autostart: boolean;
   onThemeChange: (t: Theme) => void;
-  onLanguageChange: (l: Language) => void;
-  onAutostartChange: (e: boolean) => void;
   onSetActiveProfile: () => void;
-  onExportConfig: () => void;
-  onImportConfig: () => void;
 }> = {}) {
   const i18n = await createI18n("pt-BR");
   const props = {
     theme: "dark" as Theme,
-    language: "auto" as Language,
-    autostart: false,
     onThemeChange: vi.fn(),
-    onLanguageChange: vi.fn(),
-    onAutostartChange: vi.fn(),
     ...overrides,
   };
   const utils = render(
@@ -52,19 +41,6 @@ describe("AppearanceSection", () => {
     expect(props.onThemeChange).toHaveBeenCalledWith("light");
   });
 
-  it("pre-selects the current language in the select", async () => {
-    await renderSection({ language: "en" });
-    const select = screen.getByLabelText(/idioma/i) as HTMLSelectElement;
-    expect(select.value).toBe("en");
-  });
-
-  it("calls onLanguageChange when a different language is selected", async () => {
-    const user = userEvent.setup();
-    const { props } = await renderSection({ language: "auto" });
-    await user.selectOptions(screen.getByLabelText(/idioma/i), "ptBr");
-    expect(props.onLanguageChange).toHaveBeenCalledWith("ptBr");
-  });
-
   it("does not render the set-active button when onSetActiveProfile is undefined", async () => {
     await renderSection();
     expect(screen.queryByTestId("set-active-profile")).toBeNull();
@@ -78,42 +54,5 @@ describe("AppearanceSection", () => {
     expect(btn).toBeTruthy();
     await user.click(btn);
     expect(onSetActiveProfile).toHaveBeenCalledTimes(1);
-  });
-
-  it("autostart checkbox reflects the current value", async () => {
-    await renderSection({ autostart: true });
-    const cb = screen.getByTestId("autostart-toggle") as HTMLInputElement;
-    expect(cb.checked).toBe(true);
-  });
-
-  it("calls onAutostartChange when the checkbox is toggled", async () => {
-    const user = userEvent.setup();
-    const { props } = await renderSection({ autostart: false });
-    await user.click(screen.getByTestId("autostart-toggle"));
-    expect(props.onAutostartChange).toHaveBeenCalledWith(true);
-  });
-
-  it("does not render export/import buttons when callbacks are absent", async () => {
-    await renderSection();
-    expect(screen.queryByTestId("export-config")).toBeNull();
-    expect(screen.queryByTestId("import-config")).toBeNull();
-  });
-
-  it("renders and invokes the export-config callback when clicked", async () => {
-    const user = userEvent.setup();
-    const onExportConfig = vi.fn();
-    await renderSection({ onExportConfig });
-    const btn = screen.getByTestId("export-config");
-    await user.click(btn);
-    expect(onExportConfig).toHaveBeenCalledTimes(1);
-  });
-
-  it("renders and invokes the import-config callback when clicked", async () => {
-    const user = userEvent.setup();
-    const onImportConfig = vi.fn();
-    await renderSection({ onImportConfig });
-    const btn = screen.getByTestId("import-config");
-    await user.click(btn);
-    expect(onImportConfig).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/settings/__tests__/SettingsApp.test.tsx
+++ b/src/settings/__tests__/SettingsApp.test.tsx
@@ -170,6 +170,46 @@ describe("SettingsApp intent routing", () => {
     expect(screen.getByRole("heading", { name: /atalho global/i })).toBeTruthy();
   });
 
+  it("intent 'new-tab' targets the active profile even if another profile was selected before", async () => {
+    // Regressão da issue #23: usuário selecionou perfil B no Settings; depois
+    // clicou no "+" do donut com perfil A ativo. O intent 'new-tab' deve
+    // forçar selectedProfileId = activeProfileId = A.
+    const cfg = makeConfig({
+      activeProfileId: PROFILE_ID, // A é o ativo
+      profiles: [
+        makeProfile({ id: PROFILE_ID, name: "Perfil A" }),
+        makeProfile({ id: PROFILE_ID_2, name: "Perfil B" }),
+      ],
+    });
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(cfg);
+    const user = userEvent.setup();
+    await renderApp();
+    await waitFor(() => {
+      expect(screen.getByTestId(`profile-chip-${PROFILE_ID}`)).toBeTruthy();
+    });
+    // Usuário clica no chip do perfil B.
+    await user.click(screen.getByTestId(`profile-chip-${PROFILE_ID_2}`));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`profile-chip-${PROFILE_ID_2}`).getAttribute("aria-selected"),
+      ).toBe("true");
+    });
+    // Donut emite 'new-tab' (perfil ativo = A).
+    act(() => {
+      (events as unknown as { __emit: (n: string, p: unknown) => void }).__emit(
+        "settings-intent",
+        "new-tab",
+      );
+    });
+    // Settings deve voltar a apontar pra A.
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`profile-chip-${PROFILE_ID}`).getAttribute("aria-selected"),
+      ).toBe("true");
+    });
+    expect(screen.getByRole("heading", { name: /nova aba/i })).toBeTruthy();
+  });
+
   it("intent 'new-tab' also switches back to the tabs section when on another section", async () => {
     (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(makeConfig());
     const user = userEvent.setup();

--- a/src/settings/__tests__/SystemSection.test.tsx
+++ b/src/settings/__tests__/SystemSection.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { I18nextProvider } from "react-i18next";
+import { createI18n } from "../../core/i18n";
+import { SystemSection } from "../SystemSection";
+import type { Language } from "../../core/types/Language";
+
+async function renderSection(overrides: Partial<{
+  language: Language;
+  onLanguageChange: (l: Language) => void;
+  autostart: boolean;
+  onAutostartChange: (e: boolean) => void;
+  onExportConfig: () => void;
+  onImportConfig: () => void;
+  allowScripts: boolean;
+  onAllowScriptsChange: (a: boolean) => void;
+  autoCheckUpdates: boolean;
+  onAutoCheckUpdatesChange: (e: boolean) => void;
+  scriptHistoryEnabled: boolean;
+  onScriptHistoryEnabledChange: (e: boolean) => void;
+}> = {}) {
+  const i18n = await createI18n("pt-BR");
+  const props = {
+    language: "auto" as Language,
+    onLanguageChange: vi.fn(),
+    autostart: false,
+    onAutostartChange: vi.fn(),
+    ...overrides,
+  };
+  const utils = render(
+    <I18nextProvider i18n={i18n}>
+      <SystemSection {...props} />
+    </I18nextProvider>,
+  );
+  return { ...utils, props };
+}
+
+describe("SystemSection", () => {
+  it("pre-selects the current language in the select", async () => {
+    await renderSection({ language: "en" });
+    const select = screen.getByLabelText(/idioma/i) as HTMLSelectElement;
+    expect(select.value).toBe("en");
+  });
+
+  it("calls onLanguageChange when a different language is selected", async () => {
+    const user = userEvent.setup();
+    const { props } = await renderSection({ language: "auto" });
+    await user.selectOptions(screen.getByLabelText(/idioma/i), "ptBr");
+    expect(props.onLanguageChange).toHaveBeenCalledWith("ptBr");
+  });
+
+  it("autostart checkbox reflects the current value", async () => {
+    await renderSection({ autostart: true });
+    const cb = screen.getByTestId("autostart-toggle") as HTMLInputElement;
+    expect(cb.checked).toBe(true);
+  });
+
+  it("calls onAutostartChange when the checkbox is toggled", async () => {
+    const user = userEvent.setup();
+    const { props } = await renderSection({ autostart: false });
+    await user.click(screen.getByTestId("autostart-toggle"));
+    expect(props.onAutostartChange).toHaveBeenCalledWith(true);
+  });
+
+  it("does not render export/import buttons when callbacks are absent", async () => {
+    await renderSection();
+    expect(screen.queryByTestId("export-config")).toBeNull();
+    expect(screen.queryByTestId("import-config")).toBeNull();
+  });
+
+  it("renders and invokes the export-config callback when clicked", async () => {
+    const user = userEvent.setup();
+    const onExportConfig = vi.fn();
+    await renderSection({ onExportConfig });
+    const btn = screen.getByTestId("export-config");
+    await user.click(btn);
+    expect(onExportConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders and invokes the import-config callback when clicked", async () => {
+    const user = userEvent.setup();
+    const onImportConfig = vi.fn();
+    await renderSection({ onImportConfig });
+    const btn = screen.getByTestId("import-config");
+    await user.click(btn);
+    expect(onImportConfig).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Lote de fixes/UX a partir de issues abertas:

- **#30** — hover-hold mais devagar (default `hoverHoldMs` 800 → 1200ms) e fill radial mais transparente (0.45 → 0.25); botões edit/delete também mais leves (0.55 → 0.35).
- **#13** — donut zera estado local ao reabrir (modo profile-switcher, navegação sub-donut, hover-hold). Antes a janela era reusada via hide/show e o estado persistia, então abrir no switcher e clicar fora deixava o switcher aberto na próxima abertura.
- **#23** — intent `new-tab` (e `new-tab-in-group:`) força `selectedProfileId = activeProfileId`. Antes o Settings reusava o perfil selecionado da sessão anterior, então o "+" do donut com perfil B ativo podia abrir o editor apontando pra A.
- **#35** — nova aba **Sistema** no Settings. Move autostart, allowScripts, auto-update + UpdateCard, scriptHistoryEnabled, export/import e idioma pra ela. Aparência fica só com tema, ThemeCustomizer e "Definir como ativo".

## Test plan

- [ ] `npm test` (vitest) passa
- [ ] `npx tsc --noEmit` limpo
- [ ] Hover-hold: gesto leva ~1.2s pra preencher; preenchimento perceptivelmente mais sutil
- [ ] Donut: abrir no switcher → clicar fora → reabrir → começa em modo "tabs" no root
- [ ] Trocar perfil ativo (A→B) → "+" no donut → Settings abre com perfil B selecionado
- [ ] Aba Sistema mostra: idioma, autostart, allowScripts, auto-update, scriptHistory, export/import
- [ ] Aba Aparência mostra só: tema, ThemeCustomizer, "Definir como ativo"
