### PR TITLE
Fix/batch issues 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,10 +156,21 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      # Sanity check: cache do rust-cache@v2 já pegou um estado onde
+      # `~/.cargo/bin/cargo` era cópia de `rustup-init` (hard-link transiente
+      # do install) e o restore corrompeu binário cargo, fazendo `cargo test`
+      # falhar com "unexpected argument 'test'". `which`+`--version` força o
+      # CI a falhar cedo (e visivelmente) se o cargo voltar a ficar quebrado.
+      - name: Verify cargo shim
+        run: |
+          which cargo
+          cargo --version
+          rustc --version
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
-          key: test-macos
+          key: test-macos-v2
 
       - name: cargo test
         working-directory: src-tauri

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4325,6 +4325,8 @@ dependencies = [
 name = "tauri-app"
 version = "0.1.1"
 dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
  "mouse_position",
  "parselnk",
  "regex",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -477,8 +477,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -2681,6 +2683,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "parselnk"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0088616e6efe53ab79907b9313f4743eb3f8a16eb1e0014af810164808906dc3"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "chrono",
+ "thiserror 1.0.69",
+ "widestring",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4311,6 +4326,7 @@ name = "tauri-app"
 version = "0.1.1"
 dependencies = [
  "mouse_position",
+ "parselnk",
  "regex",
  "reqwest 0.12.28",
  "serde",
@@ -5548,6 +5564,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "widestring"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,14 @@ winreg = "0.52"
 # pro launcher e algumas apps falham em rotear via ShellExecute.
 parselnk = "0.1"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Bindings tipados pra CoreFoundation (CFString, CFURL). FFI ergonomic pra
+# chamar `LSCopyDefaultApplicationURLForURL` (Launch Services), que retorna
+# o `.app` bundle padrão pra um esquema de URL. Cobre default browser
+# detection real (vs probe baseado em `/Applications/`).
+core-foundation = "0.10"
+core-foundation-sys = "0.8"
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,6 +39,10 @@ regex = "1"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"
+# Issue #48 — parser de `.lnk` (Microsoft Shell Link) pra extrair o target
+# real do shortcut (caminho do .exe). Sem isto, picker passa o path do .lnk
+# pro launcher e algumas apps falham em rotear via ShellExecute.
+parselnk = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/apps_picker/cache.rs
+++ b/src-tauri/src/apps_picker/cache.rs
@@ -1,0 +1,224 @@
+//! Issue #48 — cache em disco da lista de apps instalados.
+//!
+//! Varredura no Windows envolve enumerar registry (HKLM + HKCU + WOW6432Node)
+//! + parsear N `.lnk` no Start Menu — pode levar 1-3s em máquinas com muitos
+//!   programas. Cache num arquivo `<app_config>/apps_cache.json` com TTL longo
+//!   (7 dias) torna a abertura subsequente do picker instantânea.
+//!
+//! Estratégia de invalidação:
+//! - **TTL hit**: cache lido + retornado direto (sem refresh).
+//! - **TTL stale** (`generated_at + TTL < now`): refresh implícito na próxima
+//!   chamada de `list_installed_apps`.
+//! - **Force refresh**: comando dedicado `refresh_installed_apps` regrava o
+//!   arquivo (botão "Atualizar lista" no `<AppPicker>`).
+//! - **Sumiço de arquivo**: o launcher do Plano 14 reporta falha quando um
+//!   path cacheado já não existe; cliente deve disparar refresh manualmente.
+//!   (V1 não tem invalidação automática por miss — mantém código simples.)
+
+use super::InstalledApp;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// TTL do cache em segundos. 7 dias é largo o bastante pra cobrir uso casual
+/// sem regravar a cada abertura. Apps recém-instalados aparecerão após user
+/// clicar "Atualizar lista" — friction aceitável pelo ganho de performance.
+pub const CACHE_TTL_SECONDS: u64 = 7 * 24 * 60 * 60;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct CachedAppsFile {
+    /// Epoch seconds quando o cache foi gerado. `0` força refresh.
+    pub generated_at: u64,
+    pub apps: Vec<InstalledApp>,
+}
+
+/// Helper puro — decide se um cache está stale dado `now`. Extraído pra
+/// permitir teste sem mockar `SystemTime`.
+pub(crate) fn is_stale(cache: &CachedAppsFile, now: u64, ttl: u64) -> bool {
+    if cache.generated_at == 0 {
+        return true;
+    }
+    cache.generated_at.saturating_add(ttl) <= now
+}
+
+/// Read + parse cache. Returns `None` em qualquer erro (arquivo ausente,
+/// JSON corrompido, IO error) — caller faz refresh.
+pub(crate) fn read_cache(path: &Path) -> Option<CachedAppsFile> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Write atomically (tmp + rename). Falha silenciosa — cache não-essencial.
+pub(crate) fn write_cache(path: &Path, cache: &CachedAppsFile) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_string_pretty(cache).map_err(std::io::Error::other)?;
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+/// Epoch seconds. Falha (clock antes de 1970) → 0 (força refresh no próximo
+/// `is_stale`).
+pub(crate) fn now_epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Orquestra leitura+refresh: lê cache; se fresh, retorna; caso contrário
+/// chama `fetcher` (varredura cara), grava cache, retorna o resultado novo.
+/// `force=true` ignora cache existente.
+pub(crate) fn load_or_refresh<F>(cache_path: &Path, force: bool, fetcher: F) -> Vec<InstalledApp>
+where
+    F: FnOnce() -> Vec<InstalledApp>,
+{
+    if !force {
+        if let Some(cache) = read_cache(cache_path) {
+            if !is_stale(&cache, now_epoch_seconds(), CACHE_TTL_SECONDS) {
+                return cache.apps;
+            }
+        }
+    }
+    let apps = fetcher();
+    let cache = CachedAppsFile {
+        generated_at: now_epoch_seconds(),
+        apps: apps.clone(),
+    };
+    let _ = write_cache(cache_path, &cache);
+    apps
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn fake_apps() -> Vec<InstalledApp> {
+        vec![InstalledApp {
+            name: "Firefox".into(),
+            value: "C:\\Firefox\\firefox.exe".into(),
+            path: "C:\\Firefox\\firefox.exe".into(),
+        }]
+    }
+
+    #[test]
+    fn is_stale_when_generated_at_zero() {
+        let cache = CachedAppsFile {
+            generated_at: 0,
+            apps: vec![],
+        };
+        assert!(is_stale(&cache, 100, 60));
+    }
+
+    #[test]
+    fn is_fresh_within_ttl_window() {
+        let cache = CachedAppsFile {
+            generated_at: 100,
+            apps: vec![],
+        };
+        assert!(!is_stale(&cache, 150, 60));
+    }
+
+    #[test]
+    fn is_stale_after_ttl_expires() {
+        let cache = CachedAppsFile {
+            generated_at: 100,
+            apps: vec![],
+        };
+        // 100 + 60 = 160; now=200 → stale.
+        assert!(is_stale(&cache, 200, 60));
+    }
+
+    #[test]
+    fn is_stale_at_exact_ttl_boundary() {
+        // Comparação `<=` é defensive: na borda, prefere refresh.
+        let cache = CachedAppsFile {
+            generated_at: 100,
+            apps: vec![],
+        };
+        assert!(is_stale(&cache, 160, 60));
+    }
+
+    #[test]
+    fn write_then_read_round_trips() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("apps_cache.json");
+        let original = CachedAppsFile {
+            generated_at: 12345,
+            apps: fake_apps(),
+        };
+        write_cache(&path, &original).unwrap();
+        let back = read_cache(&path).unwrap();
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn read_cache_returns_none_for_missing_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("missing.json");
+        assert!(read_cache(&path).is_none());
+    }
+
+    #[test]
+    fn read_cache_returns_none_for_invalid_json() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("broken.json");
+        std::fs::write(&path, "{not json").unwrap();
+        assert!(read_cache(&path).is_none());
+    }
+
+    #[test]
+    fn load_or_refresh_uses_fresh_cache_without_calling_fetcher() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("apps_cache.json");
+        // Cache fresh: generated_at = now_epoch_seconds(), TTL longo.
+        let cache = CachedAppsFile {
+            generated_at: now_epoch_seconds(),
+            apps: fake_apps(),
+        };
+        write_cache(&path, &cache).unwrap();
+        let mut called = false;
+        let out = load_or_refresh(&path, false, || {
+            called = true;
+            vec![]
+        });
+        assert!(!called, "fetcher should NOT be called when cache is fresh");
+        assert_eq!(out, fake_apps());
+    }
+
+    #[test]
+    fn load_or_refresh_calls_fetcher_when_cache_missing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("apps_cache.json");
+        let out = load_or_refresh(&path, false, fake_apps);
+        assert_eq!(out, fake_apps());
+        // Refresh writes the file.
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn load_or_refresh_force_bypasses_fresh_cache() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("apps_cache.json");
+        let stale_cache = CachedAppsFile {
+            generated_at: now_epoch_seconds(),
+            apps: vec![InstalledApp {
+                name: "OldApp".into(),
+                value: "/old".into(),
+                path: "/old".into(),
+            }],
+        };
+        write_cache(&path, &stale_cache).unwrap();
+        let mut called = false;
+        let out = load_or_refresh(&path, true, || {
+            called = true;
+            fake_apps()
+        });
+        assert!(called, "fetcher MUST be called when force=true");
+        assert_eq!(out, fake_apps());
+    }
+}

--- a/src-tauri/src/apps_picker/mod.rs
+++ b/src-tauri/src/apps_picker/mod.rs
@@ -27,6 +27,7 @@ use ts_rs::TS;
 // Plano 17 — submódulos sempre compilam (helpers puros são
 // platform-independent e podem ser testados em qualquer SO no CI). A
 // façade `list_installed_apps` decide qual ramo invocar via `cfg(target_os)`.
+pub mod cache;
 pub mod linux;
 pub mod macos;
 pub mod windows;
@@ -52,26 +53,55 @@ pub struct InstalledApp {
 
 /// Façade — delega ao ramo do SO correspondente. Todo erro de IO/registry
 /// vira `AppError::io("apps_list_failed", { reason })` no nível do command.
-pub fn list_installed_apps() -> AppResult<Vec<InstalledApp>> {
-    #[cfg(target_os = "macos")]
-    {
-        macos::list_macos_apps()
+///
+/// Issue #48 — quando `cache_path` é `Some`, usa cache em disco com TTL de
+/// 7 dias (`cache::CACHE_TTL_SECONDS`). `force=true` ignora cache existente
+/// e re-escaneia (botão "Atualizar lista"). Quando `cache_path` é `None`
+/// (testes), faz scan direto sem persistir.
+pub fn list_installed_apps(
+    cache_path: Option<&std::path::Path>,
+    force: bool,
+) -> AppResult<Vec<InstalledApp>> {
+    let scan = || -> AppResult<Vec<InstalledApp>> {
+        #[cfg(target_os = "macos")]
+        {
+            macos::list_macos_apps()
+        }
+        #[cfg(target_os = "linux")]
+        {
+            linux::list_linux_apps()
+        }
+        #[cfg(target_os = "windows")]
+        {
+            windows::list_windows_apps_combined()
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+        {
+            Err(AppError::io(
+                "apps_list_failed",
+                &[("reason", "unsupported os".to_string())],
+            ))
+        }
+    };
+
+    let Some(cache_path) = cache_path else {
+        return scan();
+    };
+    // Bridge entre `cache::load_or_refresh` (Fn-style sem Result) e `scan()`
+    // (devolve `AppResult`). Falha de scan → erro propagado direto, cache
+    // não é tocado. Sucesso → load_or_refresh grava + retorna.
+    let mut scan_err: Option<crate::errors::AppError> = None;
+    let apps = cache::load_or_refresh(cache_path, force, || match scan() {
+        Ok(apps) => apps,
+        Err(e) => {
+            scan_err = Some(e);
+            Vec::new()
+        }
+    });
+    if let Some(e) = scan_err {
+        return Err(e);
     }
-    #[cfg(target_os = "linux")]
-    {
-        linux::list_linux_apps()
-    }
-    #[cfg(target_os = "windows")]
-    {
-        windows::list_windows_apps_combined()
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    {
-        Err(AppError::io(
-            "apps_list_failed",
-            &[("reason", "unsupported os".to_string())],
-        ))
-    }
+    Ok(apps)
 }
 
 /// Helper compartilhado: dedupe por `name` case-insensitive (preserva primeiro

--- a/src-tauri/src/apps_picker/windows.rs
+++ b/src-tauri/src/apps_picker/windows.rs
@@ -24,7 +24,13 @@ use std::path::PathBuf;
 
 pub fn list_windows_apps_combined() -> AppResult<Vec<InstalledApp>> {
     let mut combined = Vec::new();
+    // Ordem importa: App Paths é a fonte mais autoritativa (path absoluto de
+    // exe registrado). Uninstall vem depois (catch apps GUI que faltam em
+    // App Paths). .lnk fica por último (fonte mais ruidosa — atalhos podem
+    // apontar pra .url, .bat, instaladores etc.). `dedupe_and_sort` mantém
+    // primeira ocorrência por `name` case-insensitive.
     combined.extend(list_app_paths());
+    combined.extend(list_uninstall_entries());
     combined.extend(list_start_menu_lnks());
     Ok(dedupe_and_sort(combined))
 }
@@ -60,6 +66,56 @@ fn list_app_paths() -> Vec<InstalledApp> {
     // Em outros SOs, registry não existe — função não faz nada.
     // Mantida pra mod compilar cross-platform (testes dos parsers puros
     // rodam em qualquer SO no CI).
+    Vec::new()
+}
+
+/// Issue #48 — escaneia o registry `Uninstall` (HKLM + HKCU + WOW6432Node)
+/// pra capturar apps GUI instaladas que não registram entry em `App Paths`.
+/// Cada subkey carrega `DisplayName` (label friendly) + `DisplayIcon` ou
+/// `InstallLocation` (path inferível pro exe). Skip entries marcadas como
+/// `SystemComponent=1` ou com `ParentKeyName` non-empty (componentes
+/// secundários de bundles maiores).
+#[cfg(target_os = "windows")]
+fn list_uninstall_entries() -> Vec<InstalledApp> {
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+    use winreg::RegKey;
+
+    let mut apps = Vec::new();
+    let paths = [
+        "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+        "Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+    ];
+    for hive in [HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER] {
+        for key_path in &paths {
+            let Ok(root) = RegKey::predef(hive).open_subkey(key_path) else {
+                continue;
+            };
+            for subkey_name in root.enum_keys().flatten() {
+                let Ok(sub) = root.open_subkey(&subkey_name) else {
+                    continue;
+                };
+                let display_name: String = sub.get_value("DisplayName").unwrap_or_default();
+                let system_component: u32 = sub.get_value("SystemComponent").unwrap_or(0);
+                let parent_key: String = sub.get_value("ParentKeyName").unwrap_or_default();
+                let display_icon: String = sub.get_value("DisplayIcon").unwrap_or_default();
+                let install_location: String = sub.get_value("InstallLocation").unwrap_or_default();
+                if let Some(app) = uninstall_entry_to_installed(
+                    &display_name,
+                    system_component,
+                    &parent_key,
+                    &display_icon,
+                    &install_location,
+                ) {
+                    apps.push(app);
+                }
+            }
+        }
+    }
+    apps
+}
+
+#[cfg(not(target_os = "windows"))]
+fn list_uninstall_entries() -> Vec<InstalledApp> {
     Vec::new()
 }
 
@@ -127,11 +183,61 @@ pub(crate) fn app_paths_entry_to_installed(
     })
 }
 
+/// Issue #48 — helper puro pra entries do registry `Uninstall`. Filtra
+/// `SystemComponent=1` e `ParentKeyName` non-empty (componentes secundários
+/// de bundles). Resolve `value` priorizando `DisplayIcon` (path do exe
+/// usado pelo Add/Remove Programs) e caindo em `InstallLocation\\app.exe`
+/// quando DisplayIcon não é um path utilizável. Returns `None` quando não
+/// for possível derivar path.
+pub(crate) fn uninstall_entry_to_installed(
+    display_name: &str,
+    system_component: u32,
+    parent_key: &str,
+    display_icon: &str,
+    install_location: &str,
+) -> Option<InstalledApp> {
+    if system_component != 0 {
+        return None;
+    }
+    if !parent_key.trim().is_empty() {
+        return None;
+    }
+    let name = display_name.trim().to_string();
+    if name.is_empty() {
+        return None;
+    }
+    // DisplayIcon pode vir como `"C:\\path\\app.exe,0"` (icon index após
+    // vírgula) ou apenas `"C:\\path\\app.exe"`. Strip qualquer sufixo `,N`.
+    let icon_path = display_icon.split(',').next().unwrap_or("").trim();
+    let icon_path = icon_path.trim_matches('"');
+    let resolved = if icon_path.to_lowercase().ends_with(".exe") {
+        Some(icon_path.to_string())
+    } else if !install_location.trim().is_empty() {
+        // Sem .exe explícito — usa InstallLocation como pasta informacional.
+        // O launcher cai no fallback do shell, então só useful como hint.
+        let loc = install_location.trim().trim_matches('"').to_string();
+        Some(loc)
+    } else {
+        None
+    };
+    let resolved = resolved?;
+    if resolved.is_empty() {
+        return None;
+    }
+    Some(InstalledApp {
+        name,
+        value: resolved.clone(),
+        path: resolved,
+    })
+}
+
 /// Helper puro: dado o caminho de um `.lnk`, devolve `InstalledApp`:
 /// - `name` = stem do arquivo (display friendly).
-/// - `value` = caminho absoluto do `.lnk`. Launcher detecta `.lnk` extensão
-///   e roteia via `tauri-plugin-opener` (ShellExecute) já que CreateProcess
-///   não resolve shell-links nativamente.
+/// - `value` = target real parseado via crate `parselnk` (path absoluto do
+///   exe alvo). Quando o parse falha — `.lnk` malformado, target aponta pra
+///   protocolo não-arquivo (`.url`), permissão negada, etc. — cai no path
+///   do próprio `.lnk` (launcher detecta extensão `.lnk` e roteia via
+///   `tauri-plugin-opener`/ShellExecute como fallback do Plano 17).
 /// - `path` = mesmo que `value`.
 pub(crate) fn lnk_path_to_installed(path: &Path) -> Option<InstalledApp> {
     if path.extension().and_then(|s| s.to_str()) != Some("lnk") {
@@ -142,11 +248,34 @@ pub(crate) fn lnk_path_to_installed(path: &Path) -> Option<InstalledApp> {
         return None;
     }
     let abs = path.to_string_lossy().into_owned();
+    let resolved = parse_lnk_target(path).unwrap_or_else(|| abs.clone());
     Some(InstalledApp {
         name: stem,
-        value: abs.clone(),
-        path: abs,
+        value: resolved.clone(),
+        path: resolved,
     })
+}
+
+#[cfg(target_os = "windows")]
+fn parse_lnk_target(path: &Path) -> Option<String> {
+    // parselnk lê os bytes do `.lnk` e expõe `link_info` com `local_base_path`
+    // (target absoluto). Falha (path inválido, .lnk malformado, sem link_info)
+    // → `None` e o caller cai no path do próprio .lnk.
+    use parselnk::Lnk;
+    let lnk = Lnk::try_from(path).ok()?;
+    let target = lnk.link_info.local_base_path?;
+    let target = target.trim();
+    if target.is_empty() {
+        return None;
+    }
+    Some(target.to_string())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn parse_lnk_target(_path: &Path) -> Option<String> {
+    // Em outros SOs não há `.lnk` real pra parsear — função existe apenas
+    // pra fechar o cfg, sempre devolve None.
+    None
 }
 
 #[cfg(test)]
@@ -210,6 +339,70 @@ mod tests {
     fn lnk_rejects_no_extension() {
         let p = PathBuf::from("/start/menu/firefox");
         assert!(lnk_path_to_installed(&p).is_none());
+    }
+
+    #[test]
+    fn uninstall_entry_resolves_display_icon_exe() {
+        let app = uninstall_entry_to_installed(
+            "Mozilla Firefox",
+            0,
+            "",
+            "\"C:\\Program Files\\Firefox\\firefox.exe\",0",
+            "C:\\Program Files\\Firefox",
+        )
+        .unwrap();
+        assert_eq!(app.name, "Mozilla Firefox");
+        assert_eq!(app.value, "C:\\Program Files\\Firefox\\firefox.exe");
+        assert_eq!(app.path, "C:\\Program Files\\Firefox\\firefox.exe");
+    }
+
+    #[test]
+    fn uninstall_entry_falls_back_to_install_location_when_icon_not_exe() {
+        let app = uninstall_entry_to_installed(
+            "VLC media player",
+            0,
+            "",
+            "C:\\Program Files\\VLC\\icon.ico,0",
+            "C:\\Program Files\\VLC",
+        )
+        .unwrap();
+        assert_eq!(app.name, "VLC media player");
+        assert_eq!(app.value, "C:\\Program Files\\VLC");
+    }
+
+    #[test]
+    fn uninstall_entry_rejects_system_component() {
+        assert!(uninstall_entry_to_installed(
+            "Hidden Update",
+            1,
+            "",
+            "C:\\Windows\\update.exe",
+            "C:\\Windows"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn uninstall_entry_rejects_child_with_parent_key() {
+        assert!(uninstall_entry_to_installed(
+            "Bundled Tool",
+            0,
+            "MainApp",
+            "C:\\App\\tool.exe",
+            "C:\\App"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn uninstall_entry_rejects_empty_display_name() {
+        assert!(uninstall_entry_to_installed("", 0, "", "C:\\app.exe", "C:\\").is_none());
+        assert!(uninstall_entry_to_installed("   ", 0, "", "C:\\app.exe", "C:\\").is_none());
+    }
+
+    #[test]
+    fn uninstall_entry_rejects_no_path_at_all() {
+        assert!(uninstall_entry_to_installed("App", 0, "", "", "").is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -833,11 +833,32 @@ pub fn set_profile_theme_overrides<R: tauri::Runtime>(
 /// erro de digitação. Async + spawn_blocking porque a enumeração faz I/O
 /// pesado (read_dir recursivo em Start Menu, registry HKLM+HKCU); rodar
 /// inline travaria a thread do tauri runtime.
+///
+/// Issue #48 — cache em disco com TTL de 7 dias. `force=true` (botão
+/// "Atualizar lista" no `<AppPicker>`) re-escaneia e regrava.
 #[tauri::command]
-pub async fn list_installed_apps() -> Result<Vec<InstalledApp>, AppError> {
-    tauri::async_runtime::spawn_blocking(apps_picker::list_installed_apps)
-        .await
-        .map_err(|e| AppError::io("apps_list_failed", &[("reason", e.to_string())]))?
+pub async fn list_installed_apps(
+    app: tauri::AppHandle,
+    force: Option<bool>,
+) -> Result<Vec<InstalledApp>, AppError> {
+    let cache_path = apps_cache_path(&app);
+    let force = force.unwrap_or(false);
+    tauri::async_runtime::spawn_blocking(move || {
+        apps_picker::list_installed_apps(cache_path.as_deref(), force)
+    })
+    .await
+    .map_err(|e| AppError::io("apps_list_failed", &[("reason", e.to_string())]))?
+}
+
+/// Resolve o caminho do cache de apps (`<app_config>/apps_cache.json`).
+/// Returns `None` quando o `app_config_dir` não está acessível (ambiente de
+/// teste sem app real, falha de IO) — caller faz scan direto sem cache.
+fn apps_cache_path(app: &tauri::AppHandle) -> Option<std::path::PathBuf> {
+    use tauri::Manager;
+    app.path()
+        .app_config_dir()
+        .ok()
+        .map(|dir| dir.join("apps_cache.json"))
 }
 
 /// Plano 21 — info do monitor pra picker no Settings. Frontend usa pra

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1617,6 +1617,7 @@ mod tests {
                 monitor: None,
                 value: "https://example.com".into(),
                 open_with: None,
+                incognito: false,
             }],
             kind: TabKind::Leaf,
             children: vec![],
@@ -1846,6 +1847,7 @@ mod tests {
                 monitor: None,
                 value: "https://r".into(),
                 open_with: None,
+                incognito: false,
             }],
             kind: crate::config::schema::TabKind::Leaf,
             children: vec![],
@@ -1860,6 +1862,7 @@ mod tests {
                 monitor: None,
                 value: "https://a1".into(),
                 open_with: None,
+                incognito: false,
             }],
             kind: crate::config::schema::TabKind::Leaf,
             children: vec![],
@@ -1874,6 +1877,7 @@ mod tests {
                 monitor: None,
                 value: "https://b1".into(),
                 open_with: None,
+                incognito: false,
             }],
             kind: crate::config::schema::TabKind::Leaf,
             children: vec![],
@@ -2459,6 +2463,7 @@ mod tests {
             monitor: None,
             value: "https://x".into(),
             open_with: None,
+            incognito: false,
         }]);
         let p = profile_with(false, vec![]);
         assert!(check_script_gating(&p, &tab, None).is_none());
@@ -2580,6 +2585,7 @@ mod tests {
                 monitor: None,
                 value: "https://x".into(),
                 open_with: None,
+                incognito: false,
             },
             Item::Script {
                 monitor: None,
@@ -2605,6 +2611,7 @@ mod tests {
             monitor: None,
             value: "https://x".into(),
             open_with: None,
+            incognito: false,
         }]);
         let tid = tab.id;
         cfg.profiles[0].tabs.push(tab);

--- a/src-tauri/src/config/migrate.rs
+++ b/src-tauri/src/config/migrate.rs
@@ -92,6 +92,7 @@ mod tests {
                     monitor: None,
                     value: "https://a.test".into(),
                     open_with: None,
+                    incognito: false,
                 }],
             }],
         }

--- a/src-tauri/src/config/schema.rs
+++ b/src-tauri/src/config/schema.rs
@@ -267,6 +267,10 @@ fn is_leaf_kind(k: &TabKind) -> bool {
     matches!(k, TabKind::Leaf)
 }
 
+fn is_default_bool(b: &bool) -> bool {
+    !b
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, TS)]
 #[ts(export, export_to = "../../src/core/types/")]
 #[serde(rename_all = "camelCase")]
@@ -293,6 +297,13 @@ pub enum Item {
         /// deserializam como `None` graças ao `#[serde(default)]`.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         monitor: Option<u32>,
+        /// Quando `true`, o launcher invoca o navegador com o flag de janela
+        /// anônima/privada apropriado (`--incognito` Chromium-likes,
+        /// `--private-window` Firefox, `--inprivate` Edge). Requer
+        /// `open_with` definido — sem navegador explícito não dá pra rotar
+        /// pra modo anônimo. Configs anteriores deserializam como `false`.
+        #[serde(default, skip_serializing_if = "is_default_bool")]
+        incognito: bool,
     },
     #[serde(rename_all = "camelCase")]
     File {
@@ -439,6 +450,7 @@ mod tests {
                     monitor: None,
                     value: "https://example.com".into(),
                     open_with: None,
+                    incognito: false,
                 }],
                 kind: TabKind::Leaf,
                 children: vec![],
@@ -490,6 +502,7 @@ mod tests {
             monitor: None,
             value: "https://x.test".into(),
             open_with: None,
+            incognito: false,
         };
         let json = serde_json::to_string(&it).unwrap();
         assert_eq!(json, "{\"kind\":\"url\",\"value\":\"https://x.test\"}");
@@ -536,6 +549,7 @@ mod tests {
                     monitor: None,
                     value: "https://a.test".into(),
                     open_with: None,
+                    incognito: false,
                 },
                 Item::File {
                     monitor: None,
@@ -562,6 +576,7 @@ mod tests {
             monitor: None,
             value: "https://x.test".into(),
             open_with: Some("firefox".into()),
+            incognito: false,
         };
         let json = serde_json::to_string(&it).unwrap();
         assert!(json.contains("\"openWith\":\"firefox\""));
@@ -592,7 +607,8 @@ mod tests {
             Item::Url {
                 monitor: None,
                 value: "https://x".into(),
-                open_with: None
+                open_with: None,
+                incognito: false,
             }
         );
         let file: Item = serde_json::from_str(r#"{"kind":"file","path":"/tmp/x"}"#).unwrap();
@@ -772,6 +788,7 @@ mod tests {
                 monitor: None,
                 value: "https://x".into(),
                 open_with: None,
+                incognito: false,
             }],
             kind: TabKind::Leaf,
             children: vec![],
@@ -817,6 +834,7 @@ mod tests {
                 monitor: None,
                 value: "https://child".into(),
                 open_with: None,
+                incognito: false,
             }],
             kind: TabKind::Leaf,
             children: vec![],
@@ -874,6 +892,7 @@ mod tests {
                 monitor: None,
                 value: "https://l".into(),
                 open_with: None,
+                incognito: false,
             }],
             kind: TabKind::Leaf,
             children: vec![],
@@ -1062,6 +1081,7 @@ mod tests {
             monitor: Some(1),
             value: "https://x".into(),
             open_with: None,
+            incognito: false,
         };
         let file = Item::File {
             monitor: Some(2),
@@ -1095,6 +1115,7 @@ mod tests {
             monitor: Some(1),
             value: "https://x".into(),
             open_with: None,
+            incognito: false,
         };
         let json = serde_json::to_string(&it).unwrap();
         assert!(json.contains("\"monitor\":1"));
@@ -1108,6 +1129,7 @@ mod tests {
             monitor: None,
             value: "https://x".into(),
             open_with: None,
+            incognito: false,
         };
         let json = serde_json::to_string(&it).unwrap();
         assert!(

--- a/src-tauri/src/config/validate.rs
+++ b/src-tauri/src/config/validate.rs
@@ -272,6 +272,8 @@ fn validate_item(profile: &Profile, tab: &Tab, item: &Item) -> AppResult<()> {
                     ],
                 )
             })?;
+            // Incognito sem open_with é OK — launcher detecta o navegador
+            // padrão do SO em runtime via `default_browser::detect()`.
         }
         Item::File { path, .. } | Item::Folder { path, .. } => {
             if path.trim().is_empty() {
@@ -443,6 +445,7 @@ mod tests {
                 monitor: None,
                 value: "not a url".into(),
                 open_with: None,
+                incognito: false,
             }],
         ));
         match validate(&cfg).unwrap_err() {
@@ -465,6 +468,7 @@ mod tests {
                 monitor: None,
                 value: "https://x.test".into(),
                 open_with: None,
+                incognito: false,
             }]
         };
         let mut t1 = tab_with(Some("A"), None, url_item());
@@ -566,6 +570,7 @@ mod tests {
                     monitor: None,
                     value: "https://a.test".into(),
                     open_with: None,
+                    incognito: false,
                 },
                 Item::File {
                     monitor: None,
@@ -593,6 +598,7 @@ mod tests {
                 monitor: None,
                 value: "https://x.test".into(),
                 open_with: None,
+                incognito: false,
             }]
         };
         let mut t1 = tab_with(Some("A"), None, url_item());
@@ -627,6 +633,7 @@ mod tests {
                 monitor: None,
                 value: "https://work.test".into(),
                 open_with: Some("firefox".into()),
+                incognito: false,
             }],
         ));
         assert!(validate(&cfg).is_ok());
@@ -642,6 +649,7 @@ mod tests {
                 monitor: None,
                 value: "https://x.test".into(),
                 open_with: None,
+                incognito: false,
             }],
         ));
         assert!(validate(&cfg).is_ok());
@@ -657,6 +665,7 @@ mod tests {
                 monitor: None,
                 value: "https://x.test".into(),
                 open_with: Some("".into()),
+                incognito: false,
             }],
         ));
         match validate(&cfg).unwrap_err() {
@@ -690,6 +699,56 @@ mod tests {
     }
 
     #[test]
+    fn incognito_without_open_with_is_valid() {
+        // Detecção runtime: launcher resolve via `default_browser::detect()`.
+        // Validação não força user a escolher navegador explícito.
+        let mut cfg = base_config();
+        cfg.profiles[0].tabs.push(tab_with(
+            Some("Anon"),
+            None,
+            vec![Item::Url {
+                monitor: None,
+                value: "https://example.com".into(),
+                open_with: None,
+                incognito: true,
+            }],
+        ));
+        assert!(validate(&cfg).is_ok());
+    }
+
+    #[test]
+    fn incognito_with_open_with_is_valid() {
+        let mut cfg = base_config();
+        cfg.profiles[0].tabs.push(tab_with(
+            Some("Anon"),
+            None,
+            vec![Item::Url {
+                monitor: None,
+                value: "https://example.com".into(),
+                open_with: Some("Firefox".into()),
+                incognito: true,
+            }],
+        ));
+        assert!(validate(&cfg).is_ok());
+    }
+
+    #[test]
+    fn incognito_false_without_open_with_is_valid() {
+        let mut cfg = base_config();
+        cfg.profiles[0].tabs.push(tab_with(
+            Some("Normal"),
+            None,
+            vec![Item::Url {
+                monitor: None,
+                value: "https://example.com".into(),
+                open_with: None,
+                incognito: false,
+            }],
+        ));
+        assert!(validate(&cfg).is_ok());
+    }
+
+    #[test]
     fn mixed_open_with_some_and_none_validates() {
         let mut cfg = base_config();
         cfg.profiles[0].tabs.push(tab_with(
@@ -700,11 +759,13 @@ mod tests {
                     monitor: None,
                     value: "https://work.test".into(),
                     open_with: Some("edge".into()),
+                    incognito: false,
                 },
                 Item::Url {
                     monitor: None,
                     value: "https://personal.test".into(),
                     open_with: None,
+                    incognito: false,
                 },
                 Item::File {
                     monitor: None,
@@ -1134,6 +1195,7 @@ mod tests {
                 monitor: None,
                 value: "https://x.test".into(),
                 open_with: None,
+                incognito: false,
             }],
         )
     }
@@ -1176,6 +1238,7 @@ mod tests {
             monitor: None,
             value: "https://x.test".into(),
             open_with: None,
+            incognito: false,
         }];
         cfg.profiles[0].tabs.push(bad);
         assert_config_code(validate(&cfg).unwrap_err(), "tab_group_has_items");
@@ -1243,6 +1306,7 @@ mod tests {
                 monitor: None,
                 value: "not a url".into(),
                 open_with: None,
+                incognito: false,
             }],
         );
         let group = group_with(Some("g"), None, vec![bad_leaf]);
@@ -1270,6 +1334,7 @@ mod tests {
                     monitor: None,
                     value: "https://a.test".into(),
                     open_with: None,
+                    incognito: false,
                 },
                 Item::File {
                     monitor: None,

--- a/src-tauri/src/default_browser/linux.rs
+++ b/src-tauri/src/default_browser/linux.rs
@@ -21,7 +21,7 @@ pub fn detect() -> Option<String> {
         return None;
     }
     eprintln!("[default_browser] xdg-settings → {desktop_filename}");
-    resolve_desktop_exec(desktop_filename)
+    resolve_desktop_exec(desktop_filename, &xdg_application_dirs())
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -30,11 +30,18 @@ pub fn detect() -> Option<String> {
 }
 
 /// Helper puro: dado o filename do `.desktop` (e.g. `firefox.desktop`),
-/// procura o arquivo em paths XDG e retorna o primeiro token executável da
-/// linha `Exec=` (via `apps_picker::linux::parse_desktop_entry`). Fallback:
-/// strip `.desktop` suffix (back-compat com instalações nativas onde stem ==
-/// binary name).
-pub(crate) fn resolve_desktop_exec(desktop_filename: &str) -> Option<String> {
+/// procura o arquivo nos `search_dirs` informados e retorna o primeiro token
+/// executável da linha `Exec=` (via `apps_picker::linux::parse_desktop_entry`).
+/// Fallback: strip `.desktop` suffix (back-compat com instalações nativas
+/// onde stem == binary name).
+///
+/// Dirs são injetadas pelo caller (em prod via `xdg_application_dirs()`,
+/// em testes via tempdir) — evita que testes mutem env global `XDG_DATA_DIRS`
+/// e gerem flakiness sob paralelismo.
+pub(crate) fn resolve_desktop_exec(
+    desktop_filename: &str,
+    search_dirs: &[std::path::PathBuf],
+) -> Option<String> {
     let name = desktop_filename.trim();
     if name.is_empty() {
         return None;
@@ -44,7 +51,7 @@ pub(crate) fn resolve_desktop_exec(desktop_filename: &str) -> Option<String> {
     } else {
         format!("{}.desktop", name)
     };
-    for base in xdg_application_dirs() {
+    for base in search_dirs {
         let full = base.join(&filename);
         if let Ok(content) = std::fs::read_to_string(&full) {
             if let Some(entry) = crate::apps_picker::linux::parse_desktop_entry(&content) {
@@ -88,34 +95,28 @@ fn xdg_application_dirs() -> Vec<std::path::PathBuf> {
     dirs
 }
 
-// Tests usam env vars XDG_DATA_DIRS que são split em `:` — incompatível com
-// paths Windows (`C:\...`). Helpers só fazem sentido logico em Linux.
-#[cfg(all(test, target_os = "linux"))]
+// Tests injetam as search_dirs como parâmetro — sem env mutation. Roda em
+// qualquer SO (helpers são platform-independent agora).
+#[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    fn write_desktop(dir: &std::path::Path, name: &str, contents: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(name), contents).unwrap();
+    }
 
     #[test]
     fn resolves_exec_via_real_desktop_file() {
         let dir = tempdir().unwrap();
         let apps_dir = dir.path().join("applications");
-        std::fs::create_dir_all(&apps_dir).unwrap();
-        let desktop_file = apps_dir.join("firefox.desktop");
-        std::fs::write(
-            &desktop_file,
+        write_desktop(
+            &apps_dir,
+            "firefox.desktop",
             "[Desktop Entry]\nName=Firefox\nExec=/usr/bin/firefox %u\nType=Application\n",
-        )
-        .unwrap();
-
-        // Stub xdg_application_dirs via env (XDG_DATA_DIRS) — funciona porque
-        // resolve_desktop_exec lê env dinamicamente.
-        // Garantir isolamento: limpa HOME pra não vazar pra outros tests
-        // paralelos. (Tests Rust em modules rodam serial dentro do binary
-        // mas paralelizam entre files; aqui basta override do XDG_DATA_DIRS.)
-        std::env::set_var("XDG_DATA_DIRS", dir.path().to_string_lossy().to_string());
-        std::env::remove_var("HOME");
-
-        let exec = resolve_desktop_exec("firefox.desktop").unwrap();
+        );
+        let exec = resolve_desktop_exec("firefox.desktop", &[apps_dir]).unwrap();
         assert_eq!(exec, "/usr/bin/firefox");
     }
 
@@ -123,49 +124,61 @@ mod tests {
     fn resolves_flatpak_exec_first_token() {
         let dir = tempdir().unwrap();
         let apps_dir = dir.path().join("applications");
-        std::fs::create_dir_all(&apps_dir).unwrap();
-        std::fs::write(
-            apps_dir.join("org.mozilla.firefox.desktop"),
+        write_desktop(
+            &apps_dir,
+            "org.mozilla.firefox.desktop",
             "[Desktop Entry]\nName=Firefox\nExec=/usr/bin/flatpak run --branch=stable org.mozilla.firefox %u\nType=Application\n",
-        )
-        .unwrap();
-        std::env::set_var("XDG_DATA_DIRS", dir.path().to_string_lossy().to_string());
-        std::env::remove_var("HOME");
-
-        // Note: real Flatpak Exec = `flatpak run --command=firefox ... org.mozilla.firefox -- %u`.
+        );
+        // Real Flatpak Exec = `flatpak run --command=firefox ... -- %u`.
         // Cobertura aqui: extrai apenas `/usr/bin/flatpak` (first token).
-        let exec = resolve_desktop_exec("org.mozilla.firefox").unwrap();
+        let exec = resolve_desktop_exec("org.mozilla.firefox", &[apps_dir]).unwrap();
         assert_eq!(exec, "/usr/bin/flatpak");
     }
 
     #[test]
     fn falls_back_to_stem_when_file_missing() {
         let dir = tempdir().unwrap();
-        std::env::set_var("XDG_DATA_DIRS", dir.path().to_string_lossy().to_string());
-        std::env::remove_var("HOME");
-        let exec = resolve_desktop_exec("nonexistent.desktop").unwrap();
+        let exec = resolve_desktop_exec("nonexistent.desktop", &[dir.path().to_path_buf()]).unwrap();
         assert_eq!(exec, "nonexistent");
     }
 
     #[test]
     fn rejects_empty_input() {
-        assert!(resolve_desktop_exec("").is_none());
-        assert!(resolve_desktop_exec("   ").is_none());
+        assert!(resolve_desktop_exec("", &[]).is_none());
+        assert!(resolve_desktop_exec("   ", &[]).is_none());
     }
 
     #[test]
     fn handles_filename_without_extension() {
         let dir = tempdir().unwrap();
         let apps_dir = dir.path().join("applications");
-        std::fs::create_dir_all(&apps_dir).unwrap();
-        std::fs::write(
-            apps_dir.join("brave.desktop"),
+        write_desktop(
+            &apps_dir,
+            "brave.desktop",
             "[Desktop Entry]\nName=Brave\nExec=brave-browser %U\nType=Application\n",
-        )
-        .unwrap();
-        std::env::set_var("XDG_DATA_DIRS", dir.path().to_string_lossy().to_string());
-        std::env::remove_var("HOME");
-        let exec = resolve_desktop_exec("brave").unwrap();
+        );
+        let exec = resolve_desktop_exec("brave", &[apps_dir]).unwrap();
         assert_eq!(exec, "brave-browser");
+    }
+
+    #[test]
+    fn first_matching_dir_wins() {
+        // User-level dir antes do system-level. Mesmo filename em ambos:
+        // resolve a versão do primeiro.
+        let dir = tempdir().unwrap();
+        let user = dir.path().join("user/applications");
+        let system = dir.path().join("system/applications");
+        write_desktop(
+            &user,
+            "firefox.desktop",
+            "[Desktop Entry]\nName=Firefox\nExec=/home/me/.local/bin/firefox\nType=Application\n",
+        );
+        write_desktop(
+            &system,
+            "firefox.desktop",
+            "[Desktop Entry]\nName=Firefox\nExec=/usr/bin/firefox\nType=Application\n",
+        );
+        let exec = resolve_desktop_exec("firefox.desktop", &[user, system]).unwrap();
+        assert_eq!(exec, "/home/me/.local/bin/firefox");
     }
 }

--- a/src-tauri/src/default_browser/linux.rs
+++ b/src-tauri/src/default_browser/linux.rs
@@ -138,7 +138,8 @@ mod tests {
     #[test]
     fn falls_back_to_stem_when_file_missing() {
         let dir = tempdir().unwrap();
-        let exec = resolve_desktop_exec("nonexistent.desktop", &[dir.path().to_path_buf()]).unwrap();
+        let exec =
+            resolve_desktop_exec("nonexistent.desktop", &[dir.path().to_path_buf()]).unwrap();
         assert_eq!(exec, "nonexistent");
     }
 

--- a/src-tauri/src/default_browser/linux.rs
+++ b/src-tauri/src/default_browser/linux.rs
@@ -1,0 +1,171 @@
+//! Linux: detecta default browser via `xdg-settings get default-web-browser`
+//! (devolve nome do `.desktop`, e.g. `firefox.desktop`). Resolve o arquivo
+//! `.desktop` nos paths XDG padrão e parseia `Exec=` pra extrair o binário
+//! real — cobre Flatpak/Snap onde o stem do `.desktop` filename ≠ binary.
+
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
+#[cfg(target_os = "linux")]
+pub fn detect() -> Option<String> {
+    use std::process::Command;
+    let output = Command::new("xdg-settings")
+        .args(["get", "default-web-browser"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let desktop_filename = stdout.trim();
+    if desktop_filename.is_empty() {
+        return None;
+    }
+    eprintln!("[default_browser] xdg-settings → {desktop_filename}");
+    resolve_desktop_exec(desktop_filename)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn detect() -> Option<String> {
+    None
+}
+
+/// Helper puro: dado o filename do `.desktop` (e.g. `firefox.desktop`),
+/// procura o arquivo em paths XDG e retorna o primeiro token executável da
+/// linha `Exec=` (via `apps_picker::linux::parse_desktop_entry`). Fallback:
+/// strip `.desktop` suffix (back-compat com instalações nativas onde stem ==
+/// binary name).
+pub(crate) fn resolve_desktop_exec(desktop_filename: &str) -> Option<String> {
+    let name = desktop_filename.trim();
+    if name.is_empty() {
+        return None;
+    }
+    let filename = if name.ends_with(".desktop") {
+        name.to_string()
+    } else {
+        format!("{}.desktop", name)
+    };
+    for base in xdg_application_dirs() {
+        let full = base.join(&filename);
+        if let Ok(content) = std::fs::read_to_string(&full) {
+            if let Some(entry) = crate::apps_picker::linux::parse_desktop_entry(&content) {
+                eprintln!(
+                    "[default_browser] resolved {filename} -> {} (from {})",
+                    entry.exec,
+                    full.display()
+                );
+                return Some(entry.exec);
+            }
+        }
+    }
+    // Fallback final: strip `.desktop` suffix e devolve stem. Útil pra
+    // instalações nativas onde Exec= refere ao mesmo nome do filename.
+    let stem = name.strip_suffix(".desktop").unwrap_or(name);
+    if stem.is_empty() {
+        None
+    } else {
+        eprintln!("[default_browser] desktop file não encontrado; fallback stem={stem}");
+        Some(stem.to_string())
+    }
+}
+
+/// Lista os dirs XDG onde `.desktop` files são procurados, em ordem de
+/// precedência (user-level antes de system-level).
+fn xdg_application_dirs() -> Vec<std::path::PathBuf> {
+    let mut dirs: Vec<std::path::PathBuf> = Vec::new();
+    if let Ok(home) = std::env::var("HOME") {
+        dirs.push(std::path::PathBuf::from(&home).join(".local/share/applications"));
+    }
+    // XDG_DATA_DIRS (colon-separated). Default per XDG spec: /usr/local/share:/usr/share.
+    let xdg_data_dirs = std::env::var("XDG_DATA_DIRS")
+        .unwrap_or_else(|_| "/usr/local/share:/usr/share".to_string());
+    for d in xdg_data_dirs.split(':') {
+        let d = d.trim();
+        if d.is_empty() {
+            continue;
+        }
+        dirs.push(std::path::PathBuf::from(d).join("applications"));
+    }
+    dirs
+}
+
+// Tests usam env vars XDG_DATA_DIRS que são split em `:` — incompatível com
+// paths Windows (`C:\...`). Helpers só fazem sentido logico em Linux.
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn resolves_exec_via_real_desktop_file() {
+        let dir = tempdir().unwrap();
+        let apps_dir = dir.path().join("applications");
+        std::fs::create_dir_all(&apps_dir).unwrap();
+        let desktop_file = apps_dir.join("firefox.desktop");
+        std::fs::write(
+            &desktop_file,
+            "[Desktop Entry]\nName=Firefox\nExec=/usr/bin/firefox %u\nType=Application\n",
+        )
+        .unwrap();
+
+        // Stub xdg_application_dirs via env (XDG_DATA_DIRS) — funciona porque
+        // resolve_desktop_exec lê env dinamicamente.
+        // Garantir isolamento: limpa HOME pra não vazar pra outros tests
+        // paralelos. (Tests Rust em modules rodam serial dentro do binary
+        // mas paralelizam entre files; aqui basta override do XDG_DATA_DIRS.)
+        std::env::set_var("XDG_DATA_DIRS", dir.path().to_string_lossy().to_string());
+        std::env::remove_var("HOME");
+
+        let exec = resolve_desktop_exec("firefox.desktop").unwrap();
+        assert_eq!(exec, "/usr/bin/firefox");
+    }
+
+    #[test]
+    fn resolves_flatpak_exec_first_token() {
+        let dir = tempdir().unwrap();
+        let apps_dir = dir.path().join("applications");
+        std::fs::create_dir_all(&apps_dir).unwrap();
+        std::fs::write(
+            apps_dir.join("org.mozilla.firefox.desktop"),
+            "[Desktop Entry]\nName=Firefox\nExec=/usr/bin/flatpak run --branch=stable org.mozilla.firefox %u\nType=Application\n",
+        )
+        .unwrap();
+        std::env::set_var("XDG_DATA_DIRS", dir.path().to_string_lossy().to_string());
+        std::env::remove_var("HOME");
+
+        // Note: real Flatpak Exec = `flatpak run --command=firefox ... org.mozilla.firefox -- %u`.
+        // Cobertura aqui: extrai apenas `/usr/bin/flatpak` (first token).
+        let exec = resolve_desktop_exec("org.mozilla.firefox").unwrap();
+        assert_eq!(exec, "/usr/bin/flatpak");
+    }
+
+    #[test]
+    fn falls_back_to_stem_when_file_missing() {
+        let dir = tempdir().unwrap();
+        std::env::set_var("XDG_DATA_DIRS", dir.path().to_string_lossy().to_string());
+        std::env::remove_var("HOME");
+        let exec = resolve_desktop_exec("nonexistent.desktop").unwrap();
+        assert_eq!(exec, "nonexistent");
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        assert!(resolve_desktop_exec("").is_none());
+        assert!(resolve_desktop_exec("   ").is_none());
+    }
+
+    #[test]
+    fn handles_filename_without_extension() {
+        let dir = tempdir().unwrap();
+        let apps_dir = dir.path().join("applications");
+        std::fs::create_dir_all(&apps_dir).unwrap();
+        std::fs::write(
+            apps_dir.join("brave.desktop"),
+            "[Desktop Entry]\nName=Brave\nExec=brave-browser %U\nType=Application\n",
+        )
+        .unwrap();
+        std::env::set_var("XDG_DATA_DIRS", dir.path().to_string_lossy().to_string());
+        std::env::remove_var("HOME");
+        let exec = resolve_desktop_exec("brave").unwrap();
+        assert_eq!(exec, "brave-browser");
+    }
+}

--- a/src-tauri/src/default_browser/macos.rs
+++ b/src-tauri/src/default_browser/macos.rs
@@ -75,15 +75,23 @@ fn detect_via_launch_services() -> Option<String> {
         return None;
     }
     let app_url = unsafe { CFURL::wrap_under_create_rule(app_url_raw) };
-    let path = app_url.get_string().to_string();
+    // `to_path()` chama `CFURLCopyFileSystemPath` que devolve o caminho
+    // POSIX já decodificado (`Google Chrome.app`, não `Google%20Chrome.app`).
+    // `get_string()` retornaria a URL crua URL-encoded — quebraria bundles
+    // com espaço/acento ao passar pra `open -na`.
+    let path = app_url
+        .to_path()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| app_url.get_string().to_string());
     eprintln!("[default_browser] LaunchServices default = {path}");
     extract_bundle_name(&path)
 }
 
 /// Helper puro: extrai o nome do bundle (`Firefox`) do path/URL de um
-/// `.app`. Aceita ambos `file:///Applications/Firefox.app/` (CFURL string)
-/// e `/Applications/Firefox.app` (POSIX path). Trim trailing `/` + strip
-/// `.app` suffix.
+/// `.app`. Aceita POSIX paths (`/Applications/Firefox.app`), CFURL strings
+/// (`file:///Applications/Firefox.app/`) e — defesa em profundidade — strings
+/// URL-encoded (`file:///Applications/Google%20Chrome.app/`). Trim trailing
+/// `/` + strip `.app` suffix + percent-decode no segmento final.
 pub(crate) fn extract_bundle_name(bundle_path: &str) -> Option<String> {
     let trimmed = bundle_path
         .trim_start_matches("file://")
@@ -91,9 +99,39 @@ pub(crate) fn extract_bundle_name(bundle_path: &str) -> Option<String> {
     let last = trimmed.rsplit('/').next()?;
     let name = last.strip_suffix(".app").unwrap_or(last);
     if name.is_empty() {
-        None
-    } else {
-        Some(name.to_string())
+        return None;
+    }
+    Some(percent_decode_minimal(name))
+}
+
+/// Decoder mínimo de percent-encoding (`%20` → ` `, `%C3%A9` → `é`). Não
+/// requer crate externa — só os escapes que aparecem em nomes de bundle.
+/// Bytes inválidos ou sequências curtas são preservados literais.
+fn percent_decode_minimal(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hex = &bytes[i + 1..i + 3];
+            if let (Some(h), Some(l)) = (hex_nibble(hex[0]), hex_nibble(hex[1])) {
+                out.push((h << 4) | l);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|_| s.to_string())
+}
+
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
     }
 }
 
@@ -153,6 +191,30 @@ mod tests {
     fn extracts_returns_none_for_empty_input() {
         assert!(extract_bundle_name("").is_none());
         assert!(extract_bundle_name("/").is_none());
+    }
+
+    #[test]
+    fn extracts_bundle_name_decodes_percent_encoded_spaces() {
+        // Defesa em profundidade: se Launch Services devolver uma URL crua
+        // (`get_string()` fallback quando `to_path()` falha), o decoder
+        // mínimo cuida do `%20`. Sem isto, `open -na Google%20Chrome` falha.
+        let s = "file:///Applications/Google%20Chrome.app/";
+        assert_eq!(extract_bundle_name(s).unwrap(), "Google Chrome");
+    }
+
+    #[test]
+    fn extracts_bundle_name_decodes_utf8_escapes() {
+        // `%C3%A9` = `é`. Caso real: aplicativos com acento (raro em
+        // bundles, mas robusto pra não quebrar silenciosamente).
+        let s = "file:///Applications/Caf%C3%A9.app";
+        assert_eq!(extract_bundle_name(s).unwrap(), "Café");
+    }
+
+    #[test]
+    fn extracts_bundle_name_preserves_literal_when_encoding_malformed() {
+        // `%ZZ` não é hex — preserva literal.
+        let s = "/Applications/Weird%ZZName.app";
+        assert_eq!(extract_bundle_name(s).unwrap(), "Weird%ZZName");
     }
 
     #[test]

--- a/src-tauri/src/default_browser/macos.rs
+++ b/src-tauri/src/default_browser/macos.rs
@@ -1,0 +1,185 @@
+//! macOS: detecta default browser via Launch Services
+//! (`LSCopyDefaultApplicationURLForURL`). Retorna o nome do `.app` bundle
+//! (e.g. `"Firefox"`) — formato que `open -na NAME --args ...` aceita pra
+//! incognito spawn. Fallback: probe `/Applications/` por bundles conhecidos
+//! quando Launch Services falhar (rare).
+
+#![cfg_attr(not(target_os = "macos"), allow(dead_code))]
+
+#[cfg(target_os = "macos")]
+pub fn detect() -> Option<String> {
+    detect_via_launch_services()
+        .or_else(|| probe_common_bundles(std::path::Path::new("/Applications")))
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn detect() -> Option<String> {
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn detect_via_launch_services() -> Option<String> {
+    use core_foundation::base::TCFType;
+    use core_foundation::string::CFString;
+    use core_foundation::url::CFURL;
+    use core_foundation_sys::base::{kCFAllocatorDefault, CFTypeRef};
+    use core_foundation_sys::string::CFStringRef;
+    use core_foundation_sys::url::CFURLRef;
+
+    type LSRolesMask = u32;
+    const K_LS_ROLES_ALL: LSRolesMask = 0xFFFF_FFFF;
+
+    // CFURLCreateWithString fica em CoreFoundation framework. Linkado via crate
+    // core-foundation. LSCopyDefaultApplicationURLForURL em CoreServices —
+    // precisa link extra (não vem com core-foundation).
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFURLCreateWithString(
+            allocator: CFTypeRef,
+            url_string: CFStringRef,
+            base_url: CFURLRef,
+        ) -> CFURLRef;
+    }
+
+    #[link(name = "CoreServices", kind = "framework")]
+    extern "C" {
+        fn LSCopyDefaultApplicationURLForURL(
+            url: CFURLRef,
+            in_role_mask: LSRolesMask,
+            out_error: *mut CFTypeRef,
+        ) -> CFURLRef;
+    }
+
+    // URL probe (`https://example.com`) — Launch Services usa o esquema
+    // (`https`) pra encontrar o handler. Conteúdo após o esquema não importa.
+    let url_str = CFString::new("https://example.com");
+    let cf_url_raw = unsafe {
+        CFURLCreateWithString(
+            kCFAllocatorDefault as CFTypeRef,
+            url_str.as_concrete_TypeRef(),
+            std::ptr::null(),
+        )
+    };
+    if cf_url_raw.is_null() {
+        eprintln!("[default_browser] CFURLCreateWithString returned null");
+        return None;
+    }
+    let cf_url = unsafe { CFURL::wrap_under_create_rule(cf_url_raw) };
+
+    let mut err: CFTypeRef = std::ptr::null();
+    let app_url_raw = unsafe {
+        LSCopyDefaultApplicationURLForURL(cf_url.as_concrete_TypeRef(), K_LS_ROLES_ALL, &mut err)
+    };
+    if app_url_raw.is_null() {
+        eprintln!("[default_browser] LSCopyDefaultApplicationURLForURL returned null");
+        return None;
+    }
+    let app_url = unsafe { CFURL::wrap_under_create_rule(app_url_raw) };
+    let path = app_url.get_string().to_string();
+    eprintln!("[default_browser] LaunchServices default = {path}");
+    extract_bundle_name(&path)
+}
+
+/// Helper puro: extrai o nome do bundle (`Firefox`) do path/URL de um
+/// `.app`. Aceita ambos `file:///Applications/Firefox.app/` (CFURL string)
+/// e `/Applications/Firefox.app` (POSIX path). Trim trailing `/` + strip
+/// `.app` suffix.
+pub(crate) fn extract_bundle_name(bundle_path: &str) -> Option<String> {
+    let trimmed = bundle_path
+        .trim_start_matches("file://")
+        .trim_end_matches('/');
+    let last = trimmed.rsplit('/').next()?;
+    let name = last.strip_suffix(".app").unwrap_or(last);
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+/// Fallback puro pra quando Launch Services falha. Probe `/Applications/`
+/// por bundles comuns na ordem de preferência. Não é detecção real do
+/// default — chute baseado em "qual navegador o user provavelmente tem".
+pub(crate) fn probe_common_bundles(dir: &std::path::Path) -> Option<String> {
+    const CANDIDATES: &[&str] = &[
+        "Google Chrome",
+        "Firefox",
+        "Microsoft Edge",
+        "Brave Browser",
+        "Vivaldi",
+        "Arc",
+        "Opera",
+        "Safari",
+    ];
+    for app in CANDIDATES {
+        let bundle = dir.join(format!("{app}.app"));
+        if bundle.exists() {
+            return Some((*app).to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn extracts_bundle_name_from_file_url() {
+        let s = "file:///Applications/Firefox.app/";
+        assert_eq!(extract_bundle_name(s).unwrap(), "Firefox");
+    }
+
+    #[test]
+    fn extracts_bundle_name_from_posix_path() {
+        let s = "/Applications/Google Chrome.app";
+        assert_eq!(extract_bundle_name(s).unwrap(), "Google Chrome");
+    }
+
+    #[test]
+    fn extracts_bundle_name_from_path_with_trailing_slash() {
+        let s = "/Applications/Safari.app/";
+        assert_eq!(extract_bundle_name(s).unwrap(), "Safari");
+    }
+
+    #[test]
+    fn extracts_bundle_name_keeps_dot_in_name() {
+        let s = "/Applications/iA Writer.app";
+        assert_eq!(extract_bundle_name(s).unwrap(), "iA Writer");
+    }
+
+    #[test]
+    fn extracts_returns_none_for_empty_input() {
+        assert!(extract_bundle_name("").is_none());
+        assert!(extract_bundle_name("/").is_none());
+    }
+
+    #[test]
+    fn probe_picks_first_existing_bundle_in_preference_order() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("Firefox.app")).unwrap();
+        std::fs::create_dir(dir.path().join("Safari.app")).unwrap();
+        assert_eq!(probe_common_bundles(dir.path()).unwrap(), "Firefox");
+    }
+
+    #[test]
+    fn probe_returns_none_when_no_known_browser_present() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("RandomApp.app")).unwrap();
+        assert!(probe_common_bundles(dir.path()).is_none());
+    }
+
+    #[test]
+    fn probe_safari_only_returns_safari() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("Safari.app")).unwrap();
+        assert_eq!(probe_common_bundles(dir.path()).unwrap(), "Safari");
+    }
+
+    #[test]
+    fn probe_empty_dir_returns_none() {
+        let dir = tempdir().unwrap();
+        assert!(probe_common_bundles(dir.path()).is_none());
+    }
+}

--- a/src-tauri/src/default_browser/mod.rs
+++ b/src-tauri/src/default_browser/mod.rs
@@ -1,0 +1,44 @@
+//! Detecção do navegador padrão do SO. Usado pelo launcher quando o item
+//! URL está marcado como `incognito=true` mas o usuário escolheu "Padrão do
+//! sistema" (`open_with=None`) — sem um navegador explícito não dá pra
+//! determinar qual flag CLI usar pra modo anônimo.
+//!
+//! Cada SO tem ramo separado:
+//! - Windows: registry `HKCU\...\UrlAssociations\https\UserChoice` →
+//!   ProgId → `HKCR\<ProgId>\shell\open\command` → primeiro token quoted/
+//!   unquoted = caminho do .exe.
+//! - Linux: shell out `xdg-settings get default-web-browser` → nome do
+//!   `.desktop` (e.g. `firefox.desktop`) → strip suffix.
+//! - macOS: sem FFI Objective-C, faz probe em `/Applications/` por bundles
+//!   comuns. Não é detecção real (LSCopyDefaultApplicationURL exige
+//!   binding), mas pega o navegador provavelmente instalado.
+//!
+//! Returns `None` quando detecção falha — launcher cai pra abrir URL
+//! normalmente (sem incognito) com log de warning.
+
+pub mod linux;
+pub mod macos;
+pub mod windows;
+
+/// Façade — delega ao ramo do SO. Returns `Some(browser_ref)` onde
+/// `browser_ref` é o que deve ser passado ao `open_url_incognito`:
+/// caminho absoluto (Windows), nome do binário (Linux), display name
+/// do bundle (macOS).
+pub fn detect() -> Option<String> {
+    #[cfg(target_os = "windows")]
+    {
+        windows::detect()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        linux::detect()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macos::detect()
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+    {
+        None
+    }
+}

--- a/src-tauri/src/default_browser/windows.rs
+++ b/src-tauri/src/default_browser/windows.rs
@@ -1,0 +1,272 @@
+//! Windows: detecta navegador padrão via Win32 `AssocQueryStringW` (mesma
+//! API que o Windows shell usa pra rotear URLs/arquivos). Cobre Store apps
+//! e Default Apps Settings, ao contrário de leitura raw do registry
+//! UserChoice (que pode estar dessincronizada).
+//!
+//! Fallback chain (caso AssocQueryStringW falhe):
+//! 1. UserChoice ProgId → `HKCR/HKCU/HKLM\Software\Classes\<ProgId>\shell\open\command`.
+//! 2. `SOFTWARE\Clients\StartMenuInternet` enum.
+
+#![cfg_attr(not(target_os = "windows"), allow(dead_code))]
+
+#[cfg(target_os = "windows")]
+#[allow(clippy::upper_case_acronyms)]
+mod ffi {
+    use std::os::raw::c_uint;
+
+    pub type DWORD = c_uint;
+    pub type HRESULT = i32;
+
+    pub const ASSOCSTR_EXECUTABLE: DWORD = 2;
+    pub const ASSOCF_NONE: DWORD = 0;
+
+    #[link(name = "shlwapi")]
+    extern "system" {
+        #[allow(non_snake_case)]
+        pub fn AssocQueryStringW(
+            flags: DWORD,
+            assoc_str: DWORD,
+            pszAssoc: *const u16,
+            pszExtra: *const u16,
+            pszOut: *mut u16,
+            pcchOut: *mut DWORD,
+        ) -> HRESULT;
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub fn detect() -> Option<String> {
+    // Primary: AssocQueryStringW resolve qual exe Windows shell usa pra
+    // abrir HTML/URLs. Cobre Store apps + Default Apps Settings. Tenta
+    // `.html` primeiro (mais confiável que protocol associations); cai pra
+    // `http`/`https` se falhar.
+    for assoc in [".html", "http", "https"] {
+        if let Some(exe) = detect_via_assoc_query(assoc) {
+            if !exe.trim().is_empty() {
+                return Some(exe);
+            }
+        }
+    }
+    eprintln!("[default_browser] AssocQueryStringW failed for all assocs; falling back to UserChoice ProgId");
+    detect_via_user_choice()
+}
+
+#[cfg(target_os = "windows")]
+fn detect_via_assoc_query(assoc: &str) -> Option<String> {
+    use ffi::*;
+    let assoc_w: Vec<u16> = assoc.encode_utf16().chain([0u16]).collect();
+    let mut size: DWORD = 260;
+    let mut buf: Vec<u16> = vec![0; size as usize];
+    let hr = unsafe {
+        AssocQueryStringW(
+            ASSOCF_NONE,
+            ASSOCSTR_EXECUTABLE,
+            assoc_w.as_ptr(),
+            std::ptr::null(),
+            buf.as_mut_ptr(),
+            &mut size,
+        )
+    };
+    if hr != 0 {
+        eprintln!("[default_browser] AssocQueryStringW({assoc}) failed: HR={hr:#x}");
+        return None;
+    }
+    let end = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+    let result = String::from_utf16(&buf[..end]).ok()?;
+    eprintln!("[default_browser] AssocQueryStringW({assoc}) -> {result}");
+    if result.trim().is_empty() {
+        None
+    } else {
+        Some(result)
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn detect_via_user_choice() -> Option<String> {
+    use winreg::enums::{HKEY_CLASSES_ROOT, HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+    use winreg::RegKey;
+
+    let user_choice = RegKey::predef(HKEY_CURRENT_USER)
+        .open_subkey(
+            "Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\https\\UserChoice",
+        )
+        .ok()?;
+    let progid: String = user_choice.get_value("ProgId").ok()?;
+    eprintln!("[default_browser] UserChoice ProgId={progid}");
+
+    let candidates: [(winreg::HKEY, String); 3] = [
+        (
+            HKEY_CLASSES_ROOT,
+            format!("{}\\shell\\open\\command", progid),
+        ),
+        (
+            HKEY_CURRENT_USER,
+            format!("Software\\Classes\\{}\\shell\\open\\command", progid),
+        ),
+        (
+            HKEY_LOCAL_MACHINE,
+            format!("Software\\Classes\\{}\\shell\\open\\command", progid),
+        ),
+    ];
+    for (hive, path) in &candidates {
+        if let Ok(cmd_key) = RegKey::predef(*hive).open_subkey(path) {
+            if let Ok(cmd) = cmd_key.get_value::<String, _>("") {
+                if let Some(exe) = parse_command_exe(&cmd) {
+                    eprintln!("[default_browser] UserChoice resolved to {exe}");
+                    return Some(exe);
+                }
+            }
+        }
+    }
+    detect_via_start_menu_internet(Some(&progid))
+}
+
+#[cfg(target_os = "windows")]
+fn detect_via_start_menu_internet(progid_hint: Option<&str>) -> Option<String> {
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+    use winreg::RegKey;
+
+    let hint = progid_hint.map(normalize_loose);
+    for hive in [HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE] {
+        let Ok(root) = RegKey::predef(hive).open_subkey("Software\\Clients\\StartMenuInternet")
+        else {
+            continue;
+        };
+        let children: Vec<String> = root.enum_keys().flatten().collect();
+        if let Some(h) = hint.as_deref() {
+            for name in &children {
+                if normalize_loose(name) == h {
+                    if let Some(exe) = read_command_from_client(&root, name) {
+                        eprintln!("[default_browser] StartMenuInternet ProgId match: {exe}");
+                        return Some(exe);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "windows")]
+fn read_command_from_client(root: &winreg::RegKey, client_name: &str) -> Option<String> {
+    let cmd_path = format!("{}\\shell\\open\\command", client_name);
+    let cmd_key = root.open_subkey(&cmd_path).ok()?;
+    let cmd: String = cmd_key.get_value("").ok()?;
+    parse_command_exe(&cmd)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn detect() -> Option<String> {
+    None
+}
+
+/// Normaliza pra comparação loose: minúsculas + drop não-alfanuméricos.
+/// `"Opera GXStable"` → `"operagxstable"`; `"Opera GX Stable"` →
+/// `"operagxstable"`. Match positivo entre ProgId e ClientName.
+fn normalize_loose(s: &str) -> String {
+    s.to_lowercase()
+        .chars()
+        .filter(|c| c.is_alphanumeric())
+        .collect()
+}
+
+/// Helper puro: extrai o caminho do exe do registry `shell\open\command`
+/// value. Formatos comuns:
+/// - `"C:\\Program Files\\Firefox\\firefox.exe" "%1"` (quoted com espaços)
+/// - `C:\\Path\\app.exe %1` (unquoted sem espaços)
+/// - `C:\\Program Files\\Internet Explorer\\iexplore.exe` (unquoted com
+///   espaços — IE registra assim; `split_whitespace` quebraria em `C:\\Program`)
+///
+/// Para o caso unquoted-com-espaços, busca substring `.exe` (case-insensitive)
+/// e considera o path tudo até o fim do `.exe`. Cobre os 3 formatos sem
+/// ambiguidade pra path windows.
+pub(crate) fn parse_command_exe(cmd: &str) -> Option<String> {
+    let cmd = cmd.trim();
+    if cmd.is_empty() {
+        return None;
+    }
+    if let Some(rest) = cmd.strip_prefix('"') {
+        let end = rest.find('"')?;
+        let token = &rest[..end];
+        if token.is_empty() {
+            return None;
+        }
+        return Some(token.to_string());
+    }
+    let lower = cmd.to_lowercase();
+    if let Some(idx) = lower.find(".exe") {
+        let end = idx + ".exe".len();
+        let exe_path = cmd[..end].trim();
+        if !exe_path.is_empty() {
+            return Some(exe_path.to_string());
+        }
+    }
+    let token = cmd.split_whitespace().next()?;
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_quoted_path_with_spaces() {
+        let cmd = "\"C:\\Program Files\\Firefox\\firefox.exe\" \"%1\"";
+        assert_eq!(
+            parse_command_exe(cmd).unwrap(),
+            "C:\\Program Files\\Firefox\\firefox.exe"
+        );
+    }
+
+    #[test]
+    fn parses_unquoted_path() {
+        let cmd = "C:\\App\\chrome.exe %1";
+        assert_eq!(parse_command_exe(cmd).unwrap(), "C:\\App\\chrome.exe");
+    }
+
+    #[test]
+    fn parses_unquoted_path_with_spaces() {
+        let cmd = "C:\\Program Files\\Internet Explorer\\iexplore.exe";
+        assert_eq!(
+            parse_command_exe(cmd).unwrap(),
+            "C:\\Program Files\\Internet Explorer\\iexplore.exe"
+        );
+    }
+
+    #[test]
+    fn parses_unquoted_path_with_spaces_and_placeholder() {
+        let cmd = "C:\\Program Files\\Mozilla Firefox\\firefox.exe %1";
+        assert_eq!(
+            parse_command_exe(cmd).unwrap(),
+            "C:\\Program Files\\Mozilla Firefox\\firefox.exe"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        assert!(parse_command_exe("").is_none());
+        assert!(parse_command_exe("   ").is_none());
+    }
+
+    #[test]
+    fn rejects_empty_quoted_token() {
+        assert!(parse_command_exe("\"\" \"%1\"").is_none());
+    }
+
+    #[test]
+    fn handles_quoted_without_args() {
+        let cmd = "\"C:\\App\\chrome.exe\"";
+        assert_eq!(parse_command_exe(cmd).unwrap(), "C:\\App\\chrome.exe");
+    }
+
+    #[test]
+    fn normalize_loose_drops_spaces_and_lowercases() {
+        assert_eq!(normalize_loose("Opera GX Stable"), "operagxstable");
+        assert_eq!(normalize_loose("Opera GXStable"), "operagxstable");
+        assert_eq!(normalize_loose("Mozilla Firefox-150"), "mozillafirefox150");
+    }
+}

--- a/src-tauri/src/donut_window/mod.rs
+++ b/src-tauri/src/donut_window/mod.rs
@@ -2,6 +2,8 @@ use crate::commands::AppState;
 use crate::config::schema::SpawnPosition;
 use crate::errors::{AppError, AppResult};
 use mouse_position::mouse_position::Mouse;
+#[cfg(target_os = "macos")]
+use tauri::LogicalPosition;
 use tauri::{
     AppHandle, LogicalSize, Manager, PhysicalPosition, Runtime, WebviewUrl, WebviewWindowBuilder,
 };
@@ -90,18 +92,47 @@ fn position_at_cursor<R: Runtime>(window: &tauri::WebviewWindow<R>, size: f64) -
         Mouse::Error => return Ok(()),
     };
 
-    let scale = window.scale_factor().map_err(|e| {
-        AppError::window("window_scale_factor_failed", &[("reason", e.to_string())])
-    })?;
-    let half = (size / 2.0) * scale;
-    let x = (pos.0 - half).round() as i32;
-    let y = (pos.1 - half).round() as i32;
-
-    window
-        .set_position(PhysicalPosition::new(x, y))
-        .map_err(|e| {
-            AppError::window("window_set_position_failed", &[("reason", e.to_string())])
+    // Cuidado com unidades: a crate `mouse_position` devolve coordenadas em
+    // unidades diferentes por SO. Tratamos cada caso na sua unidade nativa
+    // pra evitar confusão de scale especialmente em multi-monitor.
+    //
+    // - macOS: `CGEventGetLocation` retorna pontos lógicos (sistema Quartz).
+    //   Nosso `size` também é lógico (LogicalSize). Subtraímos half lógico
+    //   e setamos via LogicalPosition — Tauri converte pra físico no destino
+    //   usando o scale do monitor onde a janela ficar. Tentar multiplicar
+    //   por `window.scale_factor()` aqui quebra em Retina (mouse em pontos
+    //   * scale ≠ pixels) e em multi-monitor de DPIs diferentes (scale do
+    //   monitor anterior é usado antes da janela mover).
+    //
+    // - Windows: `GetCursorPos` retorna pixels físicos.
+    // - Linux X11: `XQueryPointer` retorna pixels físicos.
+    //   Em ambos, multiplicamos `size/2` por `scale` pra ficar em físicos e
+    //   setamos via PhysicalPosition.
+    #[cfg(target_os = "macos")]
+    {
+        let half = size / 2.0;
+        let x = pos.0 - half;
+        let y = pos.1 - half;
+        window
+            .set_position(LogicalPosition::new(x, y))
+            .map_err(|e| {
+                AppError::window("window_set_position_failed", &[("reason", e.to_string())])
+            })?;
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let scale = window.scale_factor().map_err(|e| {
+            AppError::window("window_scale_factor_failed", &[("reason", e.to_string())])
         })?;
+        let half = (size / 2.0) * scale;
+        let x = (pos.0 - half).round() as i32;
+        let y = (pos.1 - half).round() as i32;
+        window
+            .set_position(PhysicalPosition::new(x, y))
+            .map_err(|e| {
+                AppError::window("window_set_position_failed", &[("reason", e.to_string())])
+            })?;
+    }
     Ok(())
 }
 
@@ -126,14 +157,34 @@ fn position_at_active_monitor_center<R: Runtime>(
         )
     })?;
 
+    // Match cursor → monitor: comparamos cursor em pontos lógicos contra
+    // bounds do monitor em pontos lógicos. `monitor.position()`/`.size()`
+    // são **pixels físicos** em todas as plataformas (Tauri normaliza),
+    // então em macOS Retina precisamos dividir pelo scale do monitor pra
+    // chegar a pontos. Em Win/Linux cursor já é físico mas dividir por
+    // `scale=1.0` (display sem HiDPI) ou pelo scale correto produz o mesmo
+    // resultado da comparação física original — é estável cross-OS.
     let monitor = cursor
         .and_then(|(cx, cy)| {
+            let cxf = cx as f64;
+            let cyf = cy as f64;
             monitors.iter().find(|m| {
+                let scale = m.scale_factor();
                 let p = m.position();
                 let s = m.size();
-                let right = p.x + s.width as i32;
-                let bottom = p.y + s.height as i32;
-                cx >= p.x && cx < right && cy >= p.y && cy < bottom
+                #[cfg(target_os = "macos")]
+                let (px, py, sw, sh) = (
+                    p.x as f64 / scale,
+                    p.y as f64 / scale,
+                    s.width as f64 / scale,
+                    s.height as f64 / scale,
+                );
+                #[cfg(not(target_os = "macos"))]
+                let (px, py, sw, sh) = {
+                    let _ = scale;
+                    (p.x as f64, p.y as f64, s.width as f64, s.height as f64)
+                };
+                cxf >= px && cxf < px + sw && cyf >= py && cyf < py + sh
             })
         })
         .cloned()

--- a/src-tauri/src/launcher/mod.rs
+++ b/src-tauri/src/launcher/mod.rs
@@ -39,6 +39,19 @@ pub trait Opener: Send + Sync {
     fn open_path(&self, path: &str, with: Option<&str>) -> Result<(), String>;
     fn spawn_app(&self, name: &str) -> Result<(), String>;
     fn spawn_script(&self, command: &str) -> Result<(), String>;
+    /// Abre uma URL no navegador `browser` em modo anônimo/privado. Browser
+    /// é resolvido para flag CLI específico via `browser_incognito_flag`.
+    /// Implementações reais spawnam o processo direto via plugin-shell
+    /// (`tauri-plugin-opener` não aceita args customizados). Default impl
+    /// cai pro `open_url` normal e loga aviso — usado em testes que não
+    /// precisam diferenciar incognito do caminho normal.
+    fn open_url_incognito(&self, url: &str, browser: &str) -> Result<(), String> {
+        eprintln!(
+            "[opener] open_url_incognito fallback (browser={browser}): \
+             implementação não suporta incognito; abrindo modo normal"
+        );
+        self.open_url(url, Some(browser))
+    }
     /// Plano 21 — move o cursor pro centro do monitor especificado antes
     /// do launch. Browsers/apps spawnam fresh windows na tela com cursor;
     /// apps que reusam janela ignoram. Best-effort: erro retornado pra
@@ -48,6 +61,46 @@ pub trait Opener: Send + Sync {
     fn warp_cursor_to_monitor(&self, _monitor_index: u32) -> Result<(), String> {
         Ok(())
     }
+}
+
+/// Mapeia nome/path do navegador → flag CLI de modo anônimo. Match é
+/// case-insensitive em substring contra keywords conhecidas. Returns
+/// `None` quando o navegador não tem flag conhecido (ex. Safari) ou não
+/// foi reconhecido — caller decide o fallback.
+pub fn browser_incognito_flag(browser: &str) -> Option<&'static str> {
+    let lower = browser.to_lowercase();
+    // Edge/msedge → --inprivate. Chromium-likes (chrome, brave, chromium,
+    // vivaldi, opera) → --incognito. Firefox/forks → --private-window.
+    // Match Edge primeiro pra evitar colisão com "edge" em outros nomes.
+    if lower.contains("msedge") || lower.contains("microsoft edge") || lower.contains("edge.exe") {
+        return Some("--inprivate");
+    }
+    if lower.contains("firefox")
+        || lower.contains("librewolf")
+        || lower.contains("waterfox")
+        || lower.contains("zen")
+    {
+        // Firefox docs canonical: `-private-window` (single dash). Algumas
+        // builds Windows ignoram `--private-window` (double dash) e tratam
+        // como argumento literal — passa URL pra janela normal.
+        return Some("-private-window");
+    }
+    if lower.contains("opera") {
+        return Some("--private");
+    }
+    if lower.contains("chrome")
+        || lower.contains("chromium")
+        || lower.contains("brave")
+        || lower.contains("vivaldi")
+        || lower.contains("arc")
+        || lower.contains("yandex")
+        || lower.contains("duckduckgo")
+    {
+        return Some("--incognito");
+    }
+    // Safari não suporta CLI flag pra Private Browsing. Tor Browser sempre
+    // é privado por design; flag não necessária.
+    None
 }
 
 /// Resultado da tentativa de abrir uma aba: lista de erros por item.
@@ -99,9 +152,42 @@ pub fn launch_tab(
         }
         match item {
             Item::Url {
-                value, open_with, ..
+                value,
+                open_with,
+                incognito,
+                ..
             } => {
-                if let Err(e) = opener.open_url(value, open_with.as_deref()) {
+                let result = if *incognito {
+                    // Resolve navegador: explícito > detecção do default do SO.
+                    let explicit = open_with
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty());
+                    let detected = if explicit.is_none() {
+                        crate::default_browser::detect()
+                    } else {
+                        None
+                    };
+                    let browser_ref = explicit.or(detected.as_deref());
+                    eprintln!(
+                        "[launcher] incognito dispatch: explicit={:?} detected={:?} chosen={:?} url={:?}",
+                        explicit, detected, browser_ref, value
+                    );
+                    match browser_ref {
+                        Some(b) => opener.open_url_incognito(value, b),
+                        None => {
+                            eprintln!(
+                                "[launcher] incognito=true mas nenhum navegador \
+                                 detectado; abrindo URL normalmente"
+                            );
+                            opener.open_url(value, None)
+                        }
+                    }
+                } else {
+                    opener.open_url(value, open_with.as_deref())
+                };
+                if let Err(e) = result {
+                    eprintln!("[launcher] url launch falhou: {} ({})", value, e);
                     outcome.failures.push((value.clone(), e));
                 }
             }
@@ -166,6 +252,47 @@ impl<'a, R: tauri::Runtime> Opener for TauriOpener<'a, R> {
             .opener()
             .open_path(path, with)
             .map_err(|e| e.to_string())
+    }
+
+    fn open_url_incognito(&self, url: &str, browser: &str) -> Result<(), String> {
+        use std::process::Command;
+        // Resolve flag CLI específico do browser. Quando não há flag mapeado
+        // (Safari, Tor, browser desconhecido), invoca o browser apenas com
+        // a URL — vai abrir uma janela normal. Fallback intencional: melhor
+        // abrir não-anônima do que falhar.
+        let flag = browser_incognito_flag(browser);
+        eprintln!(
+            "[opener] incognito launch: browser={:?} flag={:?} url={:?}",
+            browser, flag, url
+        );
+        // std::process::Command direto em vez de tauri-plugin-shell pra
+        // evitar restrição de scope (plugin pode bloquear spawn de paths
+        // arbitrários sem allowlist explícito).
+        #[cfg(target_os = "macos")]
+        {
+            let Some(flag) = flag else {
+                return self.open_url(url, Some(browser));
+            };
+            return Command::new("open")
+                .args(["-na", browser, "--args", flag, url])
+                .spawn()
+                .map(|_| ())
+                .map_err(|e| e.to_string());
+        }
+        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        {
+            let mut cmd = Command::new(browser);
+            if let Some(f) = flag {
+                cmd.arg(f);
+            }
+            cmd.arg(url);
+            cmd.spawn().map(|_| ()).map_err(|e| e.to_string())
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+        {
+            let _ = (flag, Command::new(""));
+            self.open_url(url, Some(browser))
+        }
     }
 
     fn spawn_app(&self, name: &str) -> Result<(), String> {
@@ -256,6 +383,10 @@ mod tests {
         /// Plano 21 — registra cada chamada `warp_cursor_to_monitor`. Pré-launch:
         /// a ordem dos warps relativa aos opens é o que validamos nos tests.
         warp_calls: Mutex<Vec<u32>>,
+        /// Issue — registra cada chamada `open_url_incognito` como
+        /// `(url, browser)`. Permite que tests distingam path normal vs
+        /// incognito sem confiar no fallback default da trait.
+        incognito_calls: Mutex<Vec<Call>>,
         fail_urls: Vec<String>,
         fail_paths: Vec<String>,
         fail_apps: Vec<String>,
@@ -271,6 +402,7 @@ mod tests {
                 app_calls: Mutex::new(vec![]),
                 script_calls: Mutex::new(vec![]),
                 warp_calls: Mutex::new(vec![]),
+                incognito_calls: Mutex::new(vec![]),
                 fail_urls: vec![],
                 fail_paths: vec![],
                 fail_apps: vec![],
@@ -300,6 +432,18 @@ mod tests {
                 .push((path.to_string(), with.map(str::to_string)));
             if self.fail_paths.iter().any(|f| f == path) {
                 Err("simulated path failure".into())
+            } else {
+                Ok(())
+            }
+        }
+
+        fn open_url_incognito(&self, url: &str, browser: &str) -> Result<(), String> {
+            self.incognito_calls
+                .lock()
+                .unwrap()
+                .push((url.to_string(), Some(browser.to_string())));
+            if self.fail_urls.iter().any(|f| f == url) {
+                Err("simulated url failure".into())
             } else {
                 Ok(())
             }
@@ -346,6 +490,7 @@ mod tests {
                     value: (*u).into(),
                     open_with: None,
                     monitor: None,
+                    incognito: false,
                 })
                 .collect(),
             kind: TabKind::Leaf,
@@ -430,6 +575,7 @@ mod tests {
                 monitor: None,
                 value: "https://a".into(),
                 open_with: None,
+                incognito: false,
             },
             Item::File {
                 monitor: None,
@@ -467,6 +613,7 @@ mod tests {
                 monitor: None,
                 value: "https://a".into(),
                 open_with: None,
+                incognito: false,
             },
             Item::File {
                 monitor: None,
@@ -510,11 +657,13 @@ mod tests {
                 monitor: None,
                 value: "https://work".into(),
                 open_with: Some("edge".into()),
+                incognito: false,
             },
             Item::Url {
                 monitor: None,
                 value: "https://personal".into(),
                 open_with: None,
+                incognito: false,
             },
             Item::File {
                 monitor: None,
@@ -641,6 +790,7 @@ mod tests {
                 monitor: None,
                 value: "https://a".into(),
                 open_with: None,
+                incognito: false,
             },
             Item::File {
                 monitor: None,
@@ -717,6 +867,7 @@ mod tests {
                 monitor: None,
                 value: "https://a".into(),
                 open_with: None,
+                incognito: false,
             },
             Item::Script {
                 monitor: None,
@@ -790,6 +941,7 @@ mod tests {
                 monitor: None,
                 value: "https://a".into(),
                 open_with: None,
+                incognito: false,
             },
             Item::App {
                 monitor: None,
@@ -819,6 +971,7 @@ mod tests {
                 monitor: None,
                 value: "https://a".into(),
                 open_with: None,
+                incognito: false,
             },
             Item::App {
                 monitor: None,
@@ -838,16 +991,19 @@ mod tests {
                 monitor: Some(0),
                 value: "https://a".into(),
                 open_with: None,
+                incognito: false,
             },
             Item::Url {
                 monitor: None,
                 value: "https://b".into(),
                 open_with: None,
+                incognito: false,
             },
             Item::Url {
                 monitor: Some(1),
                 value: "https://c".into(),
                 open_with: None,
+                incognito: false,
             },
         ]);
         let outcome = launch_tab(&tab, &opener, Uuid::nil(), None).unwrap();
@@ -864,6 +1020,7 @@ mod tests {
                 monitor: Some(2),
                 value: "https://a".into(),
                 open_with: None,
+                incognito: false,
             },
             Item::File {
                 monitor: Some(1),
@@ -899,11 +1056,13 @@ mod tests {
                 monitor: Some(1),
                 value: "https://a".into(),
                 open_with: None,
+                incognito: false,
             },
             Item::Url {
                 monitor: None,
                 value: "https://b".into(),
                 open_with: None,
+                incognito: false,
             },
         ]);
         // Warp failure não impede open_url de rodar — best-effort.
@@ -924,6 +1083,7 @@ mod tests {
                 monitor: Some(2),
                 value: "https://a".into(),
                 open_with: None,
+                incognito: false,
             },
             Item::File {
                 monitor: Some(0),
@@ -937,5 +1097,97 @@ mod tests {
         // Opens nas suas respectivas filas, na ordem dos items.
         assert_eq!(opener.url_calls.lock().unwrap().len(), 1);
         assert_eq!(opener.path_calls.lock().unwrap().len(), 1);
+    }
+
+    // ---- Issue: incognito ----
+
+    #[test]
+    fn browser_flag_chromium_likes_use_incognito() {
+        for b in ["chrome.exe", "Chrome", "Brave", "vivaldi", "Chromium"] {
+            assert_eq!(browser_incognito_flag(b), Some("--incognito"));
+        }
+    }
+
+    #[test]
+    fn browser_flag_firefox_likes_use_private_window() {
+        for b in ["firefox", "Firefox", "librewolf", "Waterfox", "Zen Browser"] {
+            assert_eq!(browser_incognito_flag(b), Some("-private-window"));
+        }
+    }
+
+    #[test]
+    fn browser_flag_edge_uses_inprivate() {
+        for b in ["msedge.exe", "Microsoft Edge"] {
+            assert_eq!(browser_incognito_flag(b), Some("--inprivate"));
+        }
+    }
+
+    #[test]
+    fn browser_flag_opera_uses_private() {
+        assert_eq!(browser_incognito_flag("Opera"), Some("--private"));
+    }
+
+    #[test]
+    fn browser_flag_unknown_returns_none() {
+        assert_eq!(browser_incognito_flag("Safari"), None);
+        assert_eq!(browser_incognito_flag(""), None);
+        assert_eq!(browser_incognito_flag("Notepad"), None);
+    }
+
+    #[test]
+    fn launcher_routes_incognito_url_to_dedicated_method() {
+        let opener = MockOpener::new();
+        let tab = tab_with_items(vec![Item::Url {
+            monitor: None,
+            value: "https://example.com".into(),
+            open_with: Some("Firefox".into()),
+            incognito: true,
+        }]);
+        launch_tab(&tab, &opener, Uuid::nil(), None).unwrap();
+        // open_url normal NÃO foi chamado; open_url_incognito sim.
+        assert!(opener.url_calls.lock().unwrap().is_empty());
+        let inc = opener.incognito_calls.lock().unwrap().clone();
+        assert_eq!(
+            inc,
+            vec![("https://example.com".into(), Some("Firefox".into()))]
+        );
+    }
+
+    #[test]
+    fn launcher_uses_normal_open_when_incognito_false() {
+        let opener = MockOpener::new();
+        let tab = tab_with_items(vec![Item::Url {
+            monitor: None,
+            value: "https://example.com".into(),
+            open_with: Some("Firefox".into()),
+            incognito: false,
+        }]);
+        launch_tab(&tab, &opener, Uuid::nil(), None).unwrap();
+        // open_url chamado; incognito não.
+        assert_eq!(opener.url_calls.lock().unwrap().len(), 1);
+        assert!(opener.incognito_calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn launcher_with_incognito_and_no_open_with_attempts_default_browser() {
+        // Sem `open_with`, launcher chama `default_browser::detect()`.
+        // No ambiente de CI o detect pode achar ou não — só validamos que:
+        //   * `open_url` plain NÃO é chamado (sem fallback prematuro),
+        //   * `open_url_incognito` é chamado com algum browser_ref OU
+        //     cai pro `open_url(None)` quando detect também devolve None.
+        // Não há browser detectável garantido no CI Linux/macOS dos jobs;
+        // o teste apenas confirma que o caminho não panica e que UMA das
+        // duas rotas foi acionada (não nenhuma).
+        let opener = MockOpener::new();
+        let tab = tab_with_items(vec![Item::Url {
+            monitor: None,
+            value: "https://example.com".into(),
+            open_with: None,
+            incognito: true,
+        }]);
+        launch_tab(&tab, &opener, Uuid::nil(), None).unwrap();
+        let url_calls = opener.url_calls.lock().unwrap().len();
+        let inc_calls = opener.incognito_calls.lock().unwrap().len();
+        assert_eq!(url_calls + inc_calls, 1);
     }
 }

--- a/src-tauri/src/launcher/mod.rs
+++ b/src-tauri/src/launcher/mod.rs
@@ -52,6 +52,13 @@ pub trait Opener: Send + Sync {
         );
         self.open_url(url, Some(browser))
     }
+    /// Detecção runtime do navegador padrão do SO. Chamado pelo launcher
+    /// quando `Item::Url.incognito == true && open_with.is_none()`. Default
+    /// impl delega a `default_browser::detect()`; mocks de teste podem
+    /// override pra controlar o ramo "detected" sem depender do ambiente.
+    fn detect_default_browser(&self) -> Option<String> {
+        crate::default_browser::detect()
+    }
     /// Plano 21 — move o cursor pro centro do monitor especificado antes
     /// do launch. Browsers/apps spawnam fresh windows na tela com cursor;
     /// apps que reusam janela ignoram. Best-effort: erro retornado pra
@@ -164,7 +171,7 @@ pub fn launch_tab(
                         .map(str::trim)
                         .filter(|s| !s.is_empty());
                     let detected = if explicit.is_none() {
-                        crate::default_browser::detect()
+                        opener.detect_default_browser()
                     } else {
                         None
                     };
@@ -255,7 +262,6 @@ impl<'a, R: tauri::Runtime> Opener for TauriOpener<'a, R> {
     }
 
     fn open_url_incognito(&self, url: &str, browser: &str) -> Result<(), String> {
-        use std::process::Command;
         // Resolve flag CLI específico do browser. Quando não há flag mapeado
         // (Safari, Tor, browser desconhecido), invoca o browser apenas com
         // a URL — vai abrir uma janela normal. Fallback intencional: melhor
@@ -270,6 +276,7 @@ impl<'a, R: tauri::Runtime> Opener for TauriOpener<'a, R> {
         // arbitrários sem allowlist explícito).
         #[cfg(target_os = "macos")]
         {
+            use std::process::Command;
             let Some(flag) = flag else {
                 return self.open_url(url, Some(browser));
             };
@@ -279,8 +286,26 @@ impl<'a, R: tauri::Runtime> Opener for TauriOpener<'a, R> {
                 .map(|_| ())
                 .map_err(|e| e.to_string());
         }
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(target_os = "windows")]
         {
+            // `CREATE_NO_WINDOW = 0x0800_0000` evita o flash de console preto
+            // quando o browser é um `.exe` console-aware. Sem isto, alguns
+            // builds (Firefox Nightly, instaladores antigos) mostram cmd
+            // window por uma fração de segundo antes do GUI surgir.
+            use std::os::windows::process::CommandExt;
+            use std::process::Command;
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            let mut cmd = Command::new(browser);
+            cmd.creation_flags(CREATE_NO_WINDOW);
+            if let Some(f) = flag {
+                cmd.arg(f);
+            }
+            cmd.arg(url);
+            cmd.spawn().map(|_| ()).map_err(|e| e.to_string())
+        }
+        #[cfg(target_os = "linux")]
+        {
+            use std::process::Command;
             let mut cmd = Command::new(browser);
             if let Some(f) = flag {
                 cmd.arg(f);
@@ -290,7 +315,7 @@ impl<'a, R: tauri::Runtime> Opener for TauriOpener<'a, R> {
         }
         #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
         {
-            let _ = (flag, Command::new(""));
+            let _ = flag;
             self.open_url(url, Some(browser))
         }
     }
@@ -387,6 +412,10 @@ mod tests {
         /// `(url, browser)`. Permite que tests distingam path normal vs
         /// incognito sem confiar no fallback default da trait.
         incognito_calls: Mutex<Vec<Call>>,
+        /// Browser que `detect_default_browser` deve devolver. `None`
+        /// simula SO sem default detectável (CI Linux sem xdg-settings).
+        /// `Some(s)` injeta um browser pra exercitar o caminho "detected".
+        detected_browser: Option<String>,
         fail_urls: Vec<String>,
         fail_paths: Vec<String>,
         fail_apps: Vec<String>,
@@ -403,12 +432,18 @@ mod tests {
                 script_calls: Mutex::new(vec![]),
                 warp_calls: Mutex::new(vec![]),
                 incognito_calls: Mutex::new(vec![]),
+                detected_browser: None,
                 fail_urls: vec![],
                 fail_paths: vec![],
                 fail_apps: vec![],
                 fail_scripts: vec![],
                 fail_warps: vec![],
             }
+        }
+
+        fn with_detected(mut self, browser: &str) -> Self {
+            self.detected_browser = Some(browser.to_string());
+            self
         }
     }
 
@@ -474,6 +509,10 @@ mod tests {
             } else {
                 Ok(())
             }
+        }
+
+        fn detect_default_browser(&self) -> Option<String> {
+            self.detected_browser.clone()
         }
     }
 
@@ -1169,15 +1208,30 @@ mod tests {
     }
 
     #[test]
-    fn launcher_with_incognito_and_no_open_with_attempts_default_browser() {
-        // Sem `open_with`, launcher chama `default_browser::detect()`.
-        // No ambiente de CI o detect pode achar ou não — só validamos que:
-        //   * `open_url` plain NÃO é chamado (sem fallback prematuro),
-        //   * `open_url_incognito` é chamado com algum browser_ref OU
-        //     cai pro `open_url(None)` quando detect também devolve None.
-        // Não há browser detectável garantido no CI Linux/macOS dos jobs;
-        // o teste apenas confirma que o caminho não panica e que UMA das
-        // duas rotas foi acionada (não nenhuma).
+    fn incognito_without_open_with_uses_detected_browser() {
+        // Mock injeta "Firefox" como default detectado. Launcher deve rotar
+        // pra `open_url_incognito("...", "Firefox")` sem chamar `open_url`.
+        let opener = MockOpener::new().with_detected("Firefox");
+        let tab = tab_with_items(vec![Item::Url {
+            monitor: None,
+            value: "https://example.com".into(),
+            open_with: None,
+            incognito: true,
+        }]);
+        launch_tab(&tab, &opener, Uuid::nil(), None).unwrap();
+        assert!(opener.url_calls.lock().unwrap().is_empty());
+        let inc = opener.incognito_calls.lock().unwrap().clone();
+        assert_eq!(
+            inc,
+            vec![("https://example.com".into(), Some("Firefox".into()))]
+        );
+    }
+
+    #[test]
+    fn incognito_without_open_with_falls_back_when_no_default_detected() {
+        // Mock sem `detected_browser`. Launcher cai pro `open_url(None)`
+        // (modo normal) em vez de explodir. `open_url_incognito` não é
+        // chamado quando não há browser pra passar.
         let opener = MockOpener::new();
         let tab = tab_with_items(vec![Item::Url {
             monitor: None,
@@ -1186,8 +1240,29 @@ mod tests {
             incognito: true,
         }]);
         launch_tab(&tab, &opener, Uuid::nil(), None).unwrap();
-        let url_calls = opener.url_calls.lock().unwrap().len();
-        let inc_calls = opener.incognito_calls.lock().unwrap().len();
-        assert_eq!(url_calls + inc_calls, 1);
+        assert_eq!(
+            opener.url_calls.lock().unwrap().clone(),
+            vec![("https://example.com".into(), None)]
+        );
+        assert!(opener.incognito_calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn incognito_explicit_open_with_skips_default_detection() {
+        // Quando `open_with` é explícito, detected_browser não importa —
+        // o explícito ganha. Detected vazio mesmo com Firefox setado.
+        let opener = MockOpener::new().with_detected("ShouldNotBeUsed");
+        let tab = tab_with_items(vec![Item::Url {
+            monitor: None,
+            value: "https://example.com".into(),
+            open_with: Some("Chrome".into()),
+            incognito: true,
+        }]);
+        launch_tab(&tab, &opener, Uuid::nil(), None).unwrap();
+        let inc = opener.incognito_calls.lock().unwrap().clone();
+        assert_eq!(
+            inc,
+            vec![("https://example.com".into(), Some("Chrome".into()))]
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod apps_picker;
 mod commands;
 mod config;
 mod cursor_warp;
+mod default_browser;
 mod donut_window;
 mod errors;
 mod favicon;

--- a/src/core/ipc.ts
+++ b/src/core/ipc.ts
@@ -122,8 +122,10 @@ export const ipc = {
       overrides,
     }),
   /** Plano 17 — devolve a lista de apps instalados no SO (cross-OS via
-   *  `apps_picker/`). Read-only; não toca config. */
-  listInstalledApps: () => invoke<InstalledApp[]>("list_installed_apps"),
+   *  `apps_picker/`). Read-only; não toca config. Issue #48 — cache em
+   *  disco com TTL 7 dias; `force=true` re-escaneia e regrava. */
+  listInstalledApps: (force = false) =>
+    invoke<InstalledApp[]>("list_installed_apps", { force }),
   /** Plano 18 — verifica disponibilidade de update. `force=true` ignora o
    *  gate `should_notify` (usado pelo botão "Verificar agora"). `force=false`
    *  retorna `null` se a versão remota já foi notificada antes. */

--- a/src/core/types/Item.ts
+++ b/src/core/types/Item.ts
@@ -9,4 +9,12 @@ export type Item = { "kind": "url", value: string, openWith: string | null,
  * reusam janela existente podem ignorar. Configs anteriores
  * deserializam como `None` graças ao `#[serde(default)]`.
  */
-monitor: number | null, } | { "kind": "file", path: string, openWith: string | null, monitor: number | null, } | { "kind": "folder", path: string, openWith: string | null, monitor: number | null, } | { "kind": "app", name: string, monitor: number | null, } | { "kind": "script", command: string, trusted: boolean, monitor: number | null, };
+monitor: number | null, 
+/**
+ * Quando `true`, o launcher invoca o navegador com o flag de janela
+ * anônima/privada apropriado (`--incognito` Chromium-likes,
+ * `--private-window` Firefox, `--inprivate` Edge). Requer
+ * `open_with` definido — sem navegador explícito não dá pra rotar
+ * pra modo anônimo. Configs anteriores deserializam como `false`.
+ */
+incognito: boolean, } | { "kind": "file", path: string, openWith: string | null, monitor: number | null, } | { "kind": "folder", path: string, openWith: string | null, monitor: number | null, } | { "kind": "app", name: string, monitor: number | null, } | { "kind": "script", command: string, trusted: boolean, monitor: number | null, };

--- a/src/donut/Donut.tsx
+++ b/src/donut/Donut.tsx
@@ -28,6 +28,12 @@ import { ThemeContext } from "./themeContext";
 import { resolvePresetTokens, type ThemeTokens } from "../core/themeTokens";
 import { useRingStack, MAX_RINGS } from "./useRingStack";
 
+/** Stack de fontes sans-serif do sistema. SVG `<text>` default cai em Times
+ *  serif em vários navegadores — feio dentro do donut. Aplicado na raiz
+ *  `<svg>` pra todos os textos descendentes herdarem. */
+const DONUT_FONT_FAMILY =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif';
+
 function firstTabUrl(tab: Tab): string | null {
   for (const item of tab.items) {
     if (item.kind === "url") return item.value;
@@ -413,7 +419,12 @@ export const Donut: React.FC<DonutProps> = ({
   if (mode === "profiles" && profiles && activeProfileId && onSelectProfile) {
     return (
       <ThemeContext.Provider value={effectiveTokens}>
-        <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        <svg
+          width={size}
+          height={size}
+          viewBox={`0 0 ${size} ${size}`}
+          style={{ fontFamily: DONUT_FONT_FAMILY }}
+        >
           <ProfileSwitcher
             cx={cx}
             cy={cy}
@@ -454,6 +465,7 @@ export const Donut: React.FC<DonutProps> = ({
           width={size}
           height={size}
           viewBox={`0 0 ${size} ${size}`}
+          style={{ fontFamily: DONUT_FONT_FAMILY }}
           onMouseMove={onMouseMove}
           onMouseLeave={onMouseLeave}
           onWheel={handleWheel}

--- a/src/donut/ProfileSwitcher.tsx
+++ b/src/donut/ProfileSwitcher.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { Profile } from "../core/types/Profile";
 import { Slice } from "./Slice";
+import { IconRenderer } from "./IconRenderer";
 import { sliceAngleRange } from "./geometry";
 import { useSliceHighlight } from "./useSliceHighlight";
 
@@ -56,7 +57,6 @@ export const ProfileSwitcher: React.FC<ProfileSwitcherProps> = ({
         const label = profile.name;
         const fallbackInitial =
           profile.name.trim().charAt(0).toUpperCase() || "?";
-        const icon = profile.icon ?? fallbackInitial;
         const isActive = profile.id === activeProfileId;
         return (
           <g key={profile.id}>
@@ -68,7 +68,12 @@ export const ProfileSwitcher: React.FC<ProfileSwitcherProps> = ({
               startAngle={start}
               endAngle={end}
               label={label}
-              icon={icon}
+              iconNode={
+                <IconRenderer
+                  icon={profile.icon}
+                  fallback={fallbackInitial}
+                />
+              }
               highlighted={highlighted === i}
               onClick={() => onSelect(profile.id)}
             />

--- a/src/donut/__tests__/Donut.test.tsx
+++ b/src/donut/__tests__/Donut.test.tsx
@@ -10,7 +10,7 @@ function makeTab(id: string, name: string, order = 0): Tab {
     icon: null,
     order,
     openMode: "reuseOrNewWindow",
-    items: [{ kind: "url", value: "https://example.com", openWith: null, monitor: null }],
+    items: [{ kind: "url", value: "https://example.com", openWith: null, monitor: null , incognito: false}],
     kind: "leaf",
     children: [],
   };

--- a/src/donut/__tests__/donutSize.test.ts
+++ b/src/donut/__tests__/donutSize.test.ts
@@ -15,7 +15,7 @@ const leaf = (id: string): Tab => ({
   icon: null,
   order: 0,
   openMode: "reuseOrNewWindow",
-  items: [{ kind: "url", value: "https://x", openWith: null, monitor: null }],
+  items: [{ kind: "url", value: "https://x", openWith: null, monitor: null , incognito: false}],
   kind: "leaf",
   children: [],
 });

--- a/src/donut/__tests__/findTab.test.ts
+++ b/src/donut/__tests__/findTab.test.ts
@@ -8,7 +8,7 @@ const leaf = (id: string, name = id): Tab => ({
   icon: null,
   order: 0,
   openMode: "reuseOrNewWindow",
-  items: [{ kind: "url", value: "https://x", openWith: null, monitor: null }],
+  items: [{ kind: "url", value: "https://x", openWith: null, monitor: null , incognito: false}],
   kind: "leaf",
   children: [],
 });

--- a/src/donut/__tests__/useRingStack.test.tsx
+++ b/src/donut/__tests__/useRingStack.test.tsx
@@ -9,7 +9,7 @@ const leaf = (id: string, name = id): Tab => ({
   icon: null,
   order: 0,
   openMode: "reuseOrNewWindow",
-  items: [{ kind: "url", value: "https://x", openWith: null, monitor: null }],
+  items: [{ kind: "url", value: "https://x", openWith: null, monitor: null , incognito: false}],
   kind: "leaf",
   children: [],
 });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -286,6 +286,8 @@
       "addItemApp": "Add app",
       "addItemScript": "Add script",
       "scriptTrustedLabel": "Trust (run without confirmation)",
+      "incognitoLabel": "Private",
+      "incognitoHint": "Opens in private/incognito mode. Uses the browser chosen in \"Open with\"; with \"System default\", the app detects the OS default browser.",
       "openWithLabel": "Open with",
       "openWithPlaceholder": "e.g. firefox, code",
       "openWithHint": "OS program/handler. Empty = system default.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -163,7 +163,6 @@
       "importConfirm": "Importing will replace your entire current configuration (profiles, tabs, shortcut, theme). Continue?",
       "importShortcutWarning": "Configuration imported, but the global shortcut for the new active profile could not be registered (likely already in use by another app). Restart DonutTabs or change the shortcut in Settings.",
       "update": {
-        "heading": "Updates",
         "currentVersion": "Current version: v{{version}}",
         "autoCheckLabel": "Check for updates automatically at launch",
         "autoCheckHint": "When enabled, the app checks once on launch and notifies you of new versions.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -211,7 +211,9 @@
       "pickButton": "🎨 Pick",
       "tabEmoji": "Emoji",
       "tabLucide": "Lucide",
-      "searchPlaceholder": "Search icon…"
+      "searchPlaceholder": "Search icon…",
+      "clear": "Clear icon",
+      "changeChip": "Change icon"
     },
     "appearance": {
       "sectionTitle": "Appearance",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -309,6 +309,7 @@
       "tabKindLeaf": "Tab (links)",
       "tabKindGroup": "Group (sub-donut)",
       "kindLabel": "Type",
+      "headerValue": "Value",
       "groupChildrenLabel": "Group contents",
       "groupChildrenEmpty": "No items yet. Add tabs or subgroups.",
       "addChildTab": "+ Add tab",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -211,7 +211,9 @@
       "pickButton": "🎨 Escolher",
       "tabEmoji": "Emoji",
       "tabLucide": "Lucide",
-      "searchPlaceholder": "Buscar ícone…"
+      "searchPlaceholder": "Buscar ícone…",
+      "clear": "Limpar ícone",
+      "changeChip": "Trocar ícone"
     },
     "appearance": {
       "sectionTitle": "Aparência",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -309,6 +309,7 @@
       "tabKindLeaf": "Aba (links)",
       "tabKindGroup": "Grupo (sub-donut)",
       "kindLabel": "Tipo",
+      "headerValue": "Valor",
       "groupChildrenLabel": "Conteúdo do grupo",
       "groupChildrenEmpty": "Nenhum item ainda. Adicione abas ou subgrupos.",
       "addChildTab": "+ Adicionar aba",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -286,6 +286,8 @@
       "addItemApp": "Adicionar app",
       "addItemScript": "Adicionar script",
       "scriptTrustedLabel": "Confiar (executa sem confirmação)",
+      "incognitoLabel": "Anônima",
+      "incognitoHint": "Abre em modo anônimo/privado. Usa o navegador escolhido em \"Abrir com\"; se for \"Padrão do sistema\", o app detecta o navegador padrão do SO.",
       "openWithLabel": "Abrir com",
       "openWithPlaceholder": "ex.: firefox, code",
       "openWithHint": "Programa/handler do SO. Vazio = padrão do sistema.",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -163,7 +163,6 @@
       "importConfirm": "Importar substitui toda a configuração atual (perfis, abas, atalho, tema). Continuar?",
       "importShortcutWarning": "Configuração importada, mas o atalho global do novo perfil ativo não pôde ser registrado (provavelmente em uso por outro app). Reinicie o DonutTabs ou ajuste o atalho em Configurações.",
       "update": {
-        "heading": "Atualizações",
         "currentVersion": "Versão atual: v{{version}}",
         "autoCheckLabel": "Verificar atualizações automaticamente no início",
         "autoCheckHint": "Quando ligado, o app verifica uma vez ao abrir e avisa se houver versão nova.",

--- a/src/settings/AppPicker.tsx
+++ b/src/settings/AppPicker.tsx
@@ -35,20 +35,24 @@ export const AppPicker: React.FC<AppPickerProps> = ({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  const load = useCallback(async () => {
-    setState({ status: "loading" });
-    try {
-      const apps = await (fetcher ? fetcher() : ipc.listInstalledApps());
-      setState({ status: "loaded", apps });
-    } catch (err) {
-      setState({
-        status: "error",
-        message: t("settings.appPicker.errorFetch", {
-          reason: translateAppError(err, t),
-        }),
-      });
-    }
-  }, [fetcher, t]);
+  const load = useCallback(
+    async (force = false) => {
+      setState({ status: "loading" });
+      try {
+        // Issue #48 — `force=true` (botão Atualizar) ignora cache e re-escaneia.
+        const apps = await (fetcher ? fetcher() : ipc.listInstalledApps(force));
+        setState({ status: "loaded", apps });
+      } catch (err) {
+        setState({
+          status: "error",
+          message: t("settings.appPicker.errorFetch", {
+            reason: translateAppError(err, t),
+          }),
+        });
+      }
+    },
+    [fetcher, t],
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -152,7 +156,7 @@ export const AppPicker: React.FC<AppPickerProps> = ({
           <button
             type="button"
             data-testid="app-picker-refresh"
-            onClick={() => void load()}
+            onClick={() => void load(true)}
             style={{
               background: "transparent",
               color: "var(--fg)",

--- a/src/settings/DraggableProfileList.tsx
+++ b/src/settings/DraggableProfileList.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import type { Profile } from "../core/types/Profile";
 import { useDragReorder } from "./useDragReorder";
+import { IconDisplay } from "./IconDisplay";
 
 export interface DraggableProfileListProps {
   profiles: Profile[];
@@ -99,7 +100,7 @@ export const DraggableProfileList: React.FC<DraggableProfileListProps> = ({
               outline: "none",
             }}
           >
-            <span aria-hidden="true">{p.icon ? p.icon : fallbackChar}</span>
+            <IconDisplay icon={p.icon} fallback={fallbackChar} size={16} />
             <span>{p.name}</span>
             {isActive && (
               <span

--- a/src/settings/IconDisplay.tsx
+++ b/src/settings/IconDisplay.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { getLucideComponent } from "../core/lucideRegistry";
+
+const LUCIDE_PREFIX = "lucide:";
+
+function isImageRef(s: string): boolean {
+  return (
+    /^(data:|https?:|blob:|file:|asset:)/i.test(s) ||
+    /^\/.*\.(png|jpg|jpeg|svg|gif|webp|ico)$/i.test(s)
+  );
+}
+
+export interface IconDisplayProps {
+  /** Resolves to one of: `lucide:Name`, image URL/data URL, emoji literal, null. */
+  icon?: string | null;
+  /** Fallback rendered as text when `icon` is missing or unresolved. */
+  fallback?: string;
+  /** Pixel size for both Lucide SVG and `<img>`. */
+  size?: number;
+}
+
+/**
+ * HTML-side counterpart de `IconRenderer` (que é SVG-only). Resolve um token
+ * de ícone (`lucide:Name` / data URL / emoji literal) num elemento DOM
+ * adequado pra usar em chips, listas, previews de inputs, etc.
+ */
+export const IconDisplay: React.FC<IconDisplayProps> = ({
+  icon,
+  fallback = "",
+  size = 18,
+}) => {
+  if (icon && icon.startsWith(LUCIDE_PREFIX)) {
+    const name = icon.slice(LUCIDE_PREFIX.length);
+    const Cmp = getLucideComponent(name);
+    if (Cmp) {
+      return (
+        <span
+          aria-hidden="true"
+          data-testid="icon-display-lucide"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: size,
+            height: size,
+            lineHeight: 1,
+          }}
+        >
+          <Cmp size={size} color="currentColor" />
+        </span>
+      );
+    }
+    return <span aria-hidden="true">{fallback}</span>;
+  }
+
+  if (icon && isImageRef(icon)) {
+    return (
+      <img
+        src={icon}
+        alt=""
+        width={size}
+        height={size}
+        style={{ objectFit: "contain" }}
+      />
+    );
+  }
+
+  return <span aria-hidden="true">{icon && icon.length > 0 ? icon : fallback}</span>;
+};

--- a/src/settings/IconDisplay.tsx
+++ b/src/settings/IconDisplay.tsx
@@ -65,5 +65,12 @@ export const IconDisplay: React.FC<IconDisplayProps> = ({
     );
   }
 
-  return <span aria-hidden="true">{icon && icon.length > 0 ? icon : fallback}</span>;
+  return (
+    <span
+      aria-hidden="true"
+      style={{ fontSize: size, lineHeight: 1, display: "inline-flex" }}
+    >
+      {icon && icon.length > 0 ? icon : fallback}
+    </span>
+  );
 };

--- a/src/settings/IconField.tsx
+++ b/src/settings/IconField.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { IconDisplay } from "./IconDisplay";
+import { stripLetters } from "./textUtils";
+
+const LUCIDE_PREFIX = "lucide:";
+const isLucideToken = (s: string) => s.startsWith(LUCIDE_PREFIX);
+
+export interface IconFieldProps {
+  /** Token corrente — `lucide:Name`, emoji literal, ou string vazia. */
+  value: string;
+  /** Recebe o token transformado pronto pra salvar. Para input livre,
+   *  `stripLetters` é aplicado internamente (mesma lógica que TabEditor /
+   *  ProfileEditor faziam antes). Para Lucide chip, propaga `""` no clear. */
+  onChange: (next: string) => void;
+  /** Abre o `<IconPicker>`. Mantido externo pra que a mesma instância de
+   *  picker possa servir name + icon (pickerOpen state do caller). */
+  onRequestPicker: () => void;
+  placeholder?: string;
+  /** Base test-id; sufixos `-input`, `-chip`, `-clear` aplicados nas partes. */
+  testId?: string;
+  maxLength?: number;
+}
+
+const baseFieldStyle: React.CSSProperties = {
+  background: "var(--input-bg)",
+  color: "var(--fg)",
+  border: "1px solid var(--input-border)",
+  borderRadius: 4,
+  font: "inherit",
+  boxSizing: "border-box",
+  height: 40,
+};
+/** Width do input quando vazio. Estreito o bastante pra um único emoji
+ *  caber confortavelmente — não precisa acomodar texto longo. */
+const INPUT_WIDTH = 90;
+/** Width do chip quando preenchido. Ícone (28px) + clear button + paddings. */
+const CHIP_WIDTH = 80;
+/** Tamanho do ícone dentro do chip (Lucide SVG ou emoji). */
+const CHIP_ICON_SIZE = 28;
+
+/**
+ * Campo unificado pra ícone. Quando `value` está preenchido (Lucide token,
+ * emoji ou qualquer literal), renderiza um chip mostrando o ícone resolvido
+ * (clique = reabrir picker) + botão "×" pra limpar. Quando vazio, renderiza
+ * um `<input>` pra digitar emoji. Após o usuário digitar um emoji o campo
+ * alterna pra chip — consistência com o caminho Lucide.
+ *
+ * `stripLetters` aplicado em texto livre evita que o usuário digite
+ * "lucide:Heart" manualmente como texto-bruto (o picker é o caminho canônico
+ * pra Lucide).
+ */
+export const IconField: React.FC<IconFieldProps> = ({
+  value,
+  onChange,
+  onRequestPicker,
+  placeholder,
+  testId,
+  maxLength = 64,
+}) => {
+  const { t } = useTranslation();
+
+  if (value.length > 0) {
+    return (
+      <div
+        data-testid={testId ? `${testId}-chip` : undefined}
+        style={{
+          ...baseFieldStyle,
+          width: CHIP_WIDTH,
+          display: "inline-flex",
+          alignItems: "center",
+          padding: "0 4px 0 6px",
+          gap: 4,
+        }}
+      >
+        <button
+          type="button"
+          data-testid={testId ? `${testId}-chip-icon` : undefined}
+          onClick={onRequestPicker}
+          title={t("settings.icon.changeChip")}
+          aria-label={t("settings.icon.changeChip")}
+          style={{
+            background: "transparent",
+            border: "none",
+            cursor: "pointer",
+            color: "var(--fg)",
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: 2,
+            flex: 1,
+          }}
+        >
+          <IconDisplay icon={value} fallback="?" size={CHIP_ICON_SIZE} />
+        </button>
+        <button
+          type="button"
+          data-testid={testId ? `${testId}-chip-clear` : undefined}
+          onClick={() => onChange("")}
+          title={t("settings.icon.clear")}
+          aria-label={t("settings.icon.clear")}
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "var(--muted)",
+            cursor: "pointer",
+            fontSize: 16,
+            lineHeight: 1,
+            padding: "2px 4px",
+          }}
+        >
+          ×
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <input
+      data-testid={testId}
+      value={value}
+      onChange={(e) => {
+        const raw = e.target.value;
+        onChange(isLucideToken(raw) ? raw : stripLetters(raw));
+      }}
+      placeholder={placeholder}
+      maxLength={maxLength}
+      size={2}
+      style={{
+        ...baseFieldStyle,
+        width: INPUT_WIDTH,
+        padding: "6px 8px",
+        textAlign: "center",
+        fontSize: 20,
+      }}
+    />
+  );
+};

--- a/src/settings/ItemListEditor.tsx
+++ b/src/settings/ItemListEditor.tsx
@@ -64,7 +64,36 @@ const selectStyle: React.CSSProperties = {
 };
 const openWithStyle: React.CSSProperties = {
   ...inputStyle,
-  flex: "0 0 180px",
+  flex: "0 0 150px",
+};
+
+/** Issue — "Abrir com" para `kind: "url"` deve listar só navegadores. Match
+ *  case-insensitive contra `name`/`value`/`path` do `InstalledApp`. Cobre
+ *  rótulos localizados (ex. "Google Chrome") e binários nus (ex. `chrome.exe`,
+ *  `/usr/bin/firefox`). */
+const BROWSER_KEYWORDS = [
+  "chrome",
+  "chromium",
+  "firefox",
+  "edge",
+  "msedge",
+  "brave",
+  "opera",
+  "safari",
+  "vivaldi",
+  "arc",
+  "tor browser",
+  "torbrowser",
+  "librewolf",
+  "waterfox",
+  "yandex",
+  "duckduckgo",
+  "zen browser",
+];
+
+const isBrowser = (app: InstalledApp): boolean => {
+  const haystack = `${app.name}\n${app.value}\n${app.path}`.toLowerCase();
+  return BROWSER_KEYWORDS.some((kw) => haystack.includes(kw));
 };
 const monitorSelectStyle: React.CSSProperties = {
   ...inputStyle,
@@ -267,34 +296,35 @@ export const ItemListEditor: React.FC<ItemListEditorProps> = ({
                 {t("settings.editor.appPickerButton")}
               </button>
             )}
-            {usesOpenWith(it.kind) && (
-              <select
-                aria-label={`${t("settings.editor.openWithLabel")} ${i + 1}`}
-                data-testid={`item-open-with-${i}`}
-                value={it.openWith}
-                onChange={(e) => updateAt(i, { openWith: e.target.value })}
-                title={t("settings.editor.openWithHint")}
-                style={openWithStyle}
-              >
-                <option value="">
-                  {t("settings.editor.openWithDefault")}
-                </option>
-                {(installedApps ?? []).map((app) => (
-                  <option
-                    key={`${app.value}-${app.path}`}
-                    value={app.value}
-                  >
-                    {app.name}
+            {usesOpenWith(it.kind) && (() => {
+              const pool = installedApps ?? [];
+              const filtered = it.kind === "url" ? pool.filter(isBrowser) : pool;
+              return (
+                <select
+                  aria-label={`${t("settings.editor.openWithLabel")} ${i + 1}`}
+                  data-testid={`item-open-with-${i}`}
+                  value={it.openWith}
+                  onChange={(e) => updateAt(i, { openWith: e.target.value })}
+                  title={t("settings.editor.openWithHint")}
+                  style={openWithStyle}
+                >
+                  <option value="">
+                    {t("settings.editor.openWithDefault")}
                   </option>
-                ))}
-                {it.openWith !== "" &&
-                  !(installedApps ?? []).some((a) => a.value === it.openWith) && (
-                    <option value={it.openWith}>
-                      {t("settings.editor.openWithCustom", { value: it.openWith })}
+                  {filtered.map((app) => (
+                    <option key={`${app.value}-${app.path}`} value={app.value}>
+                      {app.name}
                     </option>
-                  )}
-              </select>
-            )}
+                  ))}
+                  {it.openWith !== "" &&
+                    !filtered.some((a) => a.value === it.openWith) && (
+                      <option value={it.openWith}>
+                        {t("settings.editor.openWithCustom", { value: it.openWith })}
+                      </option>
+                    )}
+                </select>
+              );
+            })()}
             {showMonitorSelect && monitors && (
               <select
                 aria-label={`${t("settings.editor.monitorLabel")} ${i + 1}`}

--- a/src/settings/ItemListEditor.tsx
+++ b/src/settings/ItemListEditor.tsx
@@ -20,6 +20,10 @@ export interface ItemDraft {
   /** Plano 21 — índice 0-based do monitor alvo. `null` (default) = OS
    *  decide. Round-trips com o backend via `Item.monitor`. */
   monitor?: number | null;
+  /** Issue — Quando `true` e `kind === "url"`, launcher abre o navegador
+   *  escolhido (`openWith`) em modo anônimo/privado. Requer `openWith`
+   *  non-empty; combinação inválida é normalizada pra `false` no submit. */
+  incognito?: boolean;
 }
 
 export interface ItemListEditorProps {
@@ -432,6 +436,29 @@ export const ItemListEditor: React.FC<ItemListEditorProps> = ({
                   </option>
                 ))}
               </select>
+            )}
+            {it.kind === "url" && (
+              <label
+                style={{
+                  flex: "0 0 auto",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                  fontSize: 12,
+                  color: "var(--muted)",
+                  cursor: "pointer",
+                  whiteSpace: "nowrap",
+                }}
+                title={t("settings.editor.incognitoHint")}
+              >
+                <input
+                  type="checkbox"
+                  data-testid={`item-incognito-${i}`}
+                  checked={!!it.incognito}
+                  onChange={(e) => updateAt(i, { incognito: e.target.checked })}
+                />
+                {t("settings.editor.incognitoLabel")}
+              </label>
             )}
             <button
               type="button"

--- a/src/settings/ItemListEditor.tsx
+++ b/src/settings/ItemListEditor.tsx
@@ -51,6 +51,12 @@ const KIND_SUFFIX: Record<ItemKind, string> = {
 
 const inputStyle: React.CSSProperties = {
   flex: 1,
+  // `<input>`/`<textarea>` carregam min-width intrínseca (~size attr) que
+  // impede flex-shrink. Sem isto, em telas estreitas o value input não
+  // encolhe enquanto o header `<div flex:1>` sim — desalinha colunas
+  // subsequentes. selectStyle/openWithStyle/monitorSelectStyle sobrescrevem
+  // `flex` com basis fixa, então a min-width não afeta quem não cresce.
+  minWidth: 0,
   background: "var(--input-bg)",
   color: "var(--fg)",
   border: "1px solid var(--input-border)",
@@ -58,13 +64,18 @@ const inputStyle: React.CSSProperties = {
   padding: "6px 8px",
   font: "inherit",
 };
+/** Min-width do campo "Valor" — impede que o input fique impraticavelmente
+ *  estreito ao encolher a janela. Header valor cell usa o mesmo `minWidth`
+ *  pra alinhar colunas subsequentes (openWith/monitor/remove) em todas as
+ *  larguras. */
+const VALUE_MIN_WIDTH = 200;
 const selectStyle: React.CSSProperties = {
   ...inputStyle,
   flex: "0 0 110px",
 };
 const openWithStyle: React.CSSProperties = {
   ...inputStyle,
-  flex: "0 0 150px",
+  flex: "0 0 200px",
 };
 
 /** Issue — "Abrir com" para `kind: "url"` deve listar só navegadores. Match
@@ -95,6 +106,12 @@ const isBrowser = (app: InstalledApp): boolean => {
   const haystack = `${app.name}\n${app.value}\n${app.path}`.toLowerCase();
   return BROWSER_KEYWORDS.some((kw) => haystack.includes(kw));
 };
+
+/** Title Case por palavra. "google chrome" → "Google Chrome",
+ *  "MICROSOFT EDGE" → "Microsoft Edge", "firefox" → "Firefox". Preserva
+ *  separadores (espaço, hífen, etc.) usando `\b\p{L}`. */
+const titleCase = (s: string): string =>
+  s.toLocaleLowerCase().replace(/\b\p{L}/gu, (c) => c.toLocaleUpperCase());
 const monitorSelectStyle: React.CSSProperties = {
   ...inputStyle,
   flex: "0 0 140px",
@@ -107,6 +124,21 @@ const ghostBtn: React.CSSProperties = {
   padding: "4px 10px",
   cursor: "pointer",
   font: "inherit",
+};
+/** Slot fixo ocupado pelo botão "Procurar…" (file/folder) ou "📋 Procurar app"
+ *  (app). Header reserva o mesmo width quando qualquer row precisa do slot,
+ *  pra que `openWith`/`monitor`/`remove` fiquem alinhados em ambos. */
+const actionSlotStyle: React.CSSProperties = {
+  flex: "0 0 130px",
+  display: "flex",
+};
+const actionBtnStyle: React.CSSProperties = {
+  ...ghostBtn,
+  flex: 1,
+  textAlign: "center",
+  whiteSpace: "nowrap",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
 };
 const removeBtn: React.CSSProperties = {
   background: "transparent",
@@ -226,8 +258,58 @@ export const ItemListEditor: React.FC<ItemListEditorProps> = ({
   const labelFor = (kind: ItemKind) =>
     t(`settings.editor.itemKind${KIND_SUFFIX[kind]}`);
 
+  const anyUsesOpenWith = values.some((v) => usesOpenWith(v.kind));
+  const usesActionSlot = (k: ItemKind) => usesBrowse(k) || isApp(k);
+  const anyUsesActionSlot = values.some((v) => usesActionSlot(v.kind));
+
+  const headerCellStyle: React.CSSProperties = {
+    fontSize: 11,
+    fontWeight: 600,
+    textTransform: "uppercase",
+    color: "var(--muted)",
+    letterSpacing: 0.4,
+    minWidth: 0,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  };
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      {values.length > 0 && (
+        <div
+          data-testid="item-header-row"
+          style={{
+            display: "flex",
+            gap: 6,
+            alignItems: "center",
+            paddingBottom: 4,
+            borderBottom: "1px solid var(--input-border)",
+          }}
+        >
+          <div style={{ ...headerCellStyle, flex: "0 0 110px" }}>
+            {t("settings.editor.kindLabel")}
+          </div>
+          <div style={{ ...headerCellStyle, flex: 1, minWidth: VALUE_MIN_WIDTH }}>
+            {t("settings.editor.headerValue")}
+          </div>
+          {anyUsesActionSlot && (
+            <div style={actionSlotStyle} aria-hidden="true" />
+          )}
+          {anyUsesOpenWith && (
+            <div style={{ ...headerCellStyle, flex: "0 0 200px" }}>
+              {t("settings.editor.openWithLabel")}
+            </div>
+          )}
+          {showMonitorSelect && (
+            <div style={{ ...headerCellStyle, flex: "0 0 140px" }}>
+              {t("settings.editor.monitorLabel")}
+            </div>
+          )}
+          {/* spacer alinhando com o botão remover (✕) */}
+          <div style={{ flex: "0 0 36px" }} aria-hidden="true" />
+        </div>
+      )}
       {values.map((it, i) => (
         <div
           key={i}
@@ -260,6 +342,7 @@ export const ItemListEditor: React.FC<ItemListEditorProps> = ({
                 rows={3}
                 style={{
                   ...inputStyle,
+                  minWidth: VALUE_MIN_WIDTH,
                   fontFamily: "ui-monospace, Menlo, Consolas, monospace",
                   fontSize: 12,
                   resize: "vertical",
@@ -272,29 +355,33 @@ export const ItemListEditor: React.FC<ItemListEditorProps> = ({
                 value={it.value}
                 onChange={(e) => updateAt(i, { value: e.target.value })}
                 placeholder={placeholderFor(it.kind)}
-                style={inputStyle}
+                style={{ ...inputStyle, minWidth: VALUE_MIN_WIDTH }}
               />
             )}
-            {usesBrowse(it.kind) && (
-              <button
-                type="button"
-                data-testid={`item-browse-${i}`}
-                onClick={() => browse(i, it.kind)}
-                style={ghostBtn}
-              >
-                {t("settings.editor.browse")}
-              </button>
-            )}
-            {isApp(it.kind) && (
-              <button
-                type="button"
-                data-testid={`item-app-picker-${i}`}
-                title={t("settings.editor.appPickerHint")}
-                onClick={() => setAppPickerIndex(i)}
-                style={ghostBtn}
-              >
-                {t("settings.editor.appPickerButton")}
-              </button>
+            {anyUsesActionSlot && (
+              <div style={actionSlotStyle}>
+                {usesBrowse(it.kind) && (
+                  <button
+                    type="button"
+                    data-testid={`item-browse-${i}`}
+                    onClick={() => browse(i, it.kind)}
+                    style={actionBtnStyle}
+                  >
+                    {t("settings.editor.browse")}
+                  </button>
+                )}
+                {isApp(it.kind) && (
+                  <button
+                    type="button"
+                    data-testid={`item-app-picker-${i}`}
+                    title={t("settings.editor.appPickerHint")}
+                    onClick={() => setAppPickerIndex(i)}
+                    style={actionBtnStyle}
+                  >
+                    {t("settings.editor.appPickerButton")}
+                  </button>
+                )}
+              </div>
             )}
             {usesOpenWith(it.kind) && (() => {
               const pool = installedApps ?? [];
@@ -313,7 +400,7 @@ export const ItemListEditor: React.FC<ItemListEditorProps> = ({
                   </option>
                   {filtered.map((app) => (
                     <option key={`${app.value}-${app.path}`} value={app.value}>
-                      {app.name}
+                      {it.kind === "url" ? titleCase(app.name) : app.name}
                     </option>
                   ))}
                   {it.openWith !== "" &&

--- a/src/settings/ProfileEditor.tsx
+++ b/src/settings/ProfileEditor.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { translateAppError } from "../core/errors";
 import { stripLetters, graphemeCount } from "./textUtils";
 import { IconPicker } from "./IconPicker";
+import { IconDisplay } from "./IconDisplay";
 import type { Profile } from "../core/types/Profile";
 
 const LUCIDE_PREFIX = "lucide:";
@@ -137,6 +138,23 @@ export const ProfileEditor: React.FC<ProfileEditorProps> = ({
         <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           <span>{t("settings.profile.iconLabel")}</span>
           <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <span
+              data-testid="profile-icon-preview"
+              aria-hidden="true"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: 28,
+                height: 28,
+                borderRadius: 4,
+                border: "1px solid var(--input-border)",
+                background: "var(--input-bg)",
+                color: "var(--fg)",
+              }}
+            >
+              <IconDisplay icon={state.icon} fallback="?" size={18} />
+            </span>
             <input
               value={state.icon}
               onChange={(e) => {

--- a/src/settings/ProfileEditor.tsx
+++ b/src/settings/ProfileEditor.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { translateAppError } from "../core/errors";
-import { stripLetters, graphemeCount } from "./textUtils";
+import { graphemeCount } from "./textUtils";
 import { IconPicker } from "./IconPicker";
-import { IconDisplay } from "./IconDisplay";
+import { IconField } from "./IconField";
 import type { Profile } from "../core/types/Profile";
 
 const LUCIDE_PREFIX = "lucide:";
@@ -138,36 +138,12 @@ export const ProfileEditor: React.FC<ProfileEditorProps> = ({
         <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           <span>{t("settings.profile.iconLabel")}</span>
           <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <span
-              data-testid="profile-icon-preview"
-              aria-hidden="true"
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                justifyContent: "center",
-                width: 28,
-                height: 28,
-                borderRadius: 4,
-                border: "1px solid var(--input-border)",
-                background: "var(--input-bg)",
-                color: "var(--fg)",
-              }}
-            >
-              <IconDisplay icon={state.icon} fallback="?" size={18} />
-            </span>
-            <input
+            <IconField
+              testId="profile-icon"
               value={state.icon}
-              onChange={(e) => {
-                const raw = e.target.value;
-                setState({
-                  ...state,
-                  icon: isLucideToken(raw) ? raw : stripLetters(raw),
-                });
-              }}
+              onChange={(icon) => setState((s) => ({ ...s, icon }))}
+              onRequestPicker={() => setPickerOpen(true)}
               placeholder={t("settings.profile.iconPlaceholder")}
-              maxLength={64}
-              size={4}
-              style={{ ...inputStyle, width: 160 }}
             />
             <button
               type="button"

--- a/src/settings/ProfilesSection.tsx
+++ b/src/settings/ProfilesSection.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { ProfileEditor } from "./ProfileEditor";
+import { IconDisplay } from "./IconDisplay";
 import type { Profile } from "../core/types/Profile";
 
 export type ProfilesEditorMode =
@@ -119,8 +120,15 @@ export const ProfilesSection: React.FC<ProfilesSectionProps> = ({
                     gap: 8,
                   }}
                 >
-                  <span style={{ width: 20, textAlign: "center" }}>
-                    {profile.icon ?? "•"}
+                  <span
+                    style={{
+                      width: 20,
+                      display: "inline-flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <IconDisplay icon={profile.icon} fallback="•" size={16} />
                   </span>
                   <span
                     style={{

--- a/src/settings/TabEditor.tsx
+++ b/src/settings/TabEditor.tsx
@@ -3,9 +3,9 @@ import { useTranslation } from "react-i18next";
 import { ItemListEditor, type ItemDraft } from "./ItemListEditor";
 import { GroupChildrenEditor } from "./GroupChildrenEditor";
 import { translateAppError } from "../core/errors";
-import { stripLetters, graphemeCount } from "./textUtils";
+import { graphemeCount } from "./textUtils";
 import { IconPicker } from "./IconPicker";
-import { IconDisplay } from "./IconDisplay";
+import { IconField } from "./IconField";
 import type { Tab } from "../core/types/Tab";
 import type { Item } from "../core/types/Item";
 import type { OpenMode } from "../core/types/OpenMode";
@@ -298,36 +298,12 @@ export const TabEditor: React.FC<TabEditorProps> = ({
         <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           <span>{t("settings.editor.icon")}</span>
           <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <span
-              data-testid="tab-icon-preview"
-              aria-hidden="true"
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                justifyContent: "center",
-                width: 28,
-                height: 28,
-                borderRadius: 4,
-                border: "1px solid var(--input-border)",
-                background: "var(--input-bg)",
-                color: "var(--fg)",
-              }}
-            >
-              <IconDisplay icon={state.icon} fallback="?" size={18} />
-            </span>
-            <input
+            <IconField
+              testId="tab-icon"
               value={state.icon}
-              onChange={(e) => {
-                const raw = e.target.value;
-                setState({
-                  ...state,
-                  icon: isLucideToken(raw) ? raw : stripLetters(raw),
-                });
-              }}
+              onChange={(icon) => setState((s) => ({ ...s, icon }))}
+              onRequestPicker={() => setPickerOpen(true)}
               placeholder={t("settings.editor.iconPlaceholder")}
-              maxLength={64}
-              size={4}
-              style={{ ...inputStyle, width: 160 }}
             />
             <button
               type="button"

--- a/src/settings/TabEditor.tsx
+++ b/src/settings/TabEditor.tsx
@@ -62,6 +62,7 @@ function itemToDraft(it: Item): ItemDraft {
       value: it.value,
       openWith: it.openWith ?? "",
       monitor: it.monitor ?? null,
+      incognito: it.incognito,
     };
   }
   if (it.kind === "file" || it.kind === "folder") {
@@ -101,6 +102,9 @@ function draftToItem(d: ItemDraft): Item {
       value: d.value,
       openWith: ow.length > 0 ? ow : null,
       monitor,
+      // Incognito preservado mesmo sem openWith — launcher detecta o
+      // navegador padrão do SO em runtime quando necessário.
+      incognito: !!d.incognito,
     };
   }
   if (d.kind === "file" || d.kind === "folder") {
@@ -199,6 +203,7 @@ export const TabEditor: React.FC<TabEditorProps> = ({
           openWith: it.openWith.trim(),
           trusted: it.trusted,
           monitor: it.monitor ?? null,
+          incognito: it.incognito,
         }))
         .filter((it) => it.value.length > 0);
       if (trimmed.length === 0) {

--- a/src/settings/TabEditor.tsx
+++ b/src/settings/TabEditor.tsx
@@ -5,6 +5,7 @@ import { GroupChildrenEditor } from "./GroupChildrenEditor";
 import { translateAppError } from "../core/errors";
 import { stripLetters, graphemeCount } from "./textUtils";
 import { IconPicker } from "./IconPicker";
+import { IconDisplay } from "./IconDisplay";
 import type { Tab } from "../core/types/Tab";
 import type { Item } from "../core/types/Item";
 import type { OpenMode } from "../core/types/OpenMode";
@@ -297,6 +298,23 @@ export const TabEditor: React.FC<TabEditorProps> = ({
         <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           <span>{t("settings.editor.icon")}</span>
           <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <span
+              data-testid="tab-icon-preview"
+              aria-hidden="true"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: 28,
+                height: 28,
+                borderRadius: 4,
+                border: "1px solid var(--input-border)",
+                background: "var(--input-bg)",
+                color: "var(--fg)",
+              }}
+            >
+              <IconDisplay icon={state.icon} fallback="?" size={18} />
+            </span>
             <input
               value={state.icon}
               onChange={(e) => {

--- a/src/settings/TabList.tsx
+++ b/src/settings/TabList.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import type { Tab } from "../core/types/Tab";
 import { useDragReorder } from "./useDragReorder";
+import { IconDisplay } from "./IconDisplay";
 
 export interface TabListProps {
   tabs: Tab[];
@@ -126,8 +127,15 @@ export const TabList: React.FC<TabListProps> = ({
                     gap: 8,
                   }}
                 >
-                  <span style={{ width: 20, textAlign: "center" }}>
-                    {tab.icon ?? "•"}
+                  <span
+                    style={{
+                      width: 20,
+                      display: "inline-flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <IconDisplay icon={tab.icon} fallback="•" size={16} />
                   </span>
                   <span
                     style={{

--- a/src/settings/UpdateCard.tsx
+++ b/src/settings/UpdateCard.tsx
@@ -99,16 +99,11 @@ export const UpdateCard: React.FC<UpdateCardProps> = ({
     <div
       data-testid="update-card"
       style={{
-        marginTop: 12,
-        paddingTop: 12,
-        borderTop: "1px solid var(--input-border)",
         display: "flex",
         flexDirection: "column",
         gap: 8,
       }}
     >
-      <strong>{t("settings.system.update.heading")}</strong>
-
       <label
         style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
       >

--- a/src/settings/__tests__/IconDisplay.test.tsx
+++ b/src/settings/__tests__/IconDisplay.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { IconDisplay } from "../IconDisplay";
+
+describe("IconDisplay", () => {
+  it("renders Lucide component when icon = lucide:Name (registered)", () => {
+    const { container } = render(<IconDisplay icon="lucide:Coffee" />);
+    // Lucide React renderiza um <svg>; presença do svg = match.
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+
+  it("falls back to text when lucide:Name is not in the registry", () => {
+    const { container } = render(
+      <IconDisplay icon="lucide:DefinitelyNotAnIcon" fallback="X" />,
+    );
+    expect(container.querySelector("svg")).toBeNull();
+    expect(container.textContent).toBe("X");
+  });
+
+  it("renders an <img> for image-like icon refs", () => {
+    const { container } = render(<IconDisplay icon="data:image/png;base64,abc" />);
+    const img = container.querySelector("img");
+    expect(img).toBeTruthy();
+    expect(img?.getAttribute("src")).toBe("data:image/png;base64,abc");
+  });
+
+  it("renders the literal string for emoji-style icons", () => {
+    const { container } = render(<IconDisplay icon="🚀" />);
+    expect(container.textContent).toBe("🚀");
+    expect(container.querySelector("svg")).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("renders fallback when icon is null/undefined/empty", () => {
+    const { container, rerender } = render(<IconDisplay icon={null} fallback="•" />);
+    expect(container.textContent).toBe("•");
+    rerender(<IconDisplay icon={undefined} fallback="•" />);
+    expect(container.textContent).toBe("•");
+    rerender(<IconDisplay icon="" fallback="•" />);
+    expect(container.textContent).toBe("•");
+  });
+});

--- a/src/settings/__tests__/IconField.test.tsx
+++ b/src/settings/__tests__/IconField.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { I18nextProvider } from "react-i18next";
+import { createI18n } from "../../core/i18n";
+import { IconField } from "../IconField";
+
+async function renderField(
+  props: Partial<React.ComponentProps<typeof IconField>> = {},
+) {
+  const i18n = await createI18n("pt-BR");
+  const onChange = vi.fn();
+  const onRequestPicker = vi.fn();
+  const utils = render(
+    <I18nextProvider i18n={i18n}>
+      <IconField
+        testId="test-icon"
+        value={props.value ?? ""}
+        onChange={props.onChange ?? onChange}
+        onRequestPicker={props.onRequestPicker ?? onRequestPicker}
+        placeholder={props.placeholder}
+      />
+    </I18nextProvider>,
+  );
+  return { ...utils, onChange, onRequestPicker };
+}
+
+describe("IconField", () => {
+  it("renders an <input> when value is empty", async () => {
+    await renderField({ value: "" });
+    expect(screen.getByTestId("test-icon")).toBeTruthy();
+    expect(screen.queryByTestId("test-icon-chip")).toBeNull();
+  });
+
+  it("renders a chip (not input) when value is an emoji literal", async () => {
+    await renderField({ value: "🚀" });
+    expect(screen.queryByTestId("test-icon")).toBeNull();
+    const chip = screen.getByTestId("test-icon-chip");
+    expect(chip).toBeTruthy();
+    // chip mostra o emoji direto, sem campo de texto editável.
+    expect(chip.textContent).toContain("🚀");
+  });
+
+  it("emoji chip icon button opens picker on click", async () => {
+    const { onRequestPicker } = await renderField({ value: "🚀" });
+    fireEvent.click(screen.getByTestId("test-icon-chip-icon"));
+    expect(onRequestPicker).toHaveBeenCalledTimes(1);
+  });
+
+  it("emoji chip clear button emits onChange('') and switches back to input on next render", async () => {
+    const { onChange, rerender } = await renderField({ value: "🚀" });
+    fireEvent.click(screen.getByTestId("test-icon-chip-clear"));
+    expect(onChange).toHaveBeenCalledWith("");
+    const i18n = await createI18n("pt-BR");
+    rerender(
+      <I18nextProvider i18n={i18n}>
+        <IconField
+          testId="test-icon"
+          value=""
+          onChange={onChange}
+          onRequestPicker={vi.fn()}
+        />
+      </I18nextProvider>,
+    );
+    expect(screen.getByTestId("test-icon")).toBeTruthy();
+    expect(screen.queryByTestId("test-icon-chip")).toBeNull();
+  });
+
+  it("renders a chip (not input) when value is a lucide token", async () => {
+    await renderField({ value: "lucide:Coffee" });
+    expect(screen.queryByTestId("test-icon")).toBeNull();
+    expect(screen.getByTestId("test-icon-chip")).toBeTruthy();
+    // chip renderiza ícone (svg), não texto literal "lucide:Coffee"
+    expect(screen.getByTestId("test-icon-chip").textContent).not.toContain(
+      "lucide:",
+    );
+  });
+
+  it("chip icon button opens picker on click", async () => {
+    const { onRequestPicker } = await renderField({ value: "lucide:Coffee" });
+    fireEvent.click(screen.getByTestId("test-icon-chip-icon"));
+    expect(onRequestPicker).toHaveBeenCalledTimes(1);
+  });
+
+  it("chip clear button emits onChange('')", async () => {
+    const { onChange } = await renderField({ value: "lucide:Coffee" });
+    fireEvent.click(screen.getByTestId("test-icon-chip-clear"));
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("input typing emits onChange with stripLetters applied (emoji preserved)", async () => {
+    const { onChange } = await renderField({ value: "" });
+    fireEvent.change(screen.getByTestId("test-icon"), {
+      target: { value: "🚀" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith("🚀");
+  });
+
+  it("input typing strips letters from text-only values", async () => {
+    const { onChange } = await renderField({ value: "" });
+    fireEvent.change(screen.getByTestId("test-icon"), {
+      target: { value: "abc" },
+    });
+    // stripLetters drops ASCII letters — value de saída fica vazio.
+    expect(onChange).toHaveBeenLastCalledWith("");
+  });
+
+  it("any non-empty value switches to chip on next render (lucide / emoji unified)", async () => {
+    const { onChange, rerender } = await renderField({ value: "" });
+    fireEvent.change(screen.getByTestId("test-icon"), {
+      target: { value: "lucide:Star" },
+    });
+    expect(onChange).toHaveBeenCalledWith("lucide:Star");
+    const i18n = await createI18n("pt-BR");
+    rerender(
+      <I18nextProvider i18n={i18n}>
+        <IconField
+          testId="test-icon"
+          value="lucide:Star"
+          onChange={onChange}
+          onRequestPicker={vi.fn()}
+        />
+      </I18nextProvider>,
+    );
+    expect(screen.queryByTestId("test-icon")).toBeNull();
+    expect(screen.getByTestId("test-icon-chip")).toBeTruthy();
+  });
+});

--- a/src/settings/__tests__/ItemListEditor.test.tsx
+++ b/src/settings/__tests__/ItemListEditor.test.tsx
@@ -205,6 +205,27 @@ describe("ItemListEditor", () => {
     ]);
   });
 
+  it("openWith dropdown filters to browsers only on URL rows", async () => {
+    // Mock global retorna Firefox + VSCode. URL row deve mostrar só Firefox
+    // (browser); VSCode some.
+    await renderEditor([{ kind: "url", value: "https://a", openWith: "" }]);
+    await screen.findByRole("option", { name: "Firefox" });
+    const select = screen.getByTestId("item-open-with-0") as HTMLSelectElement;
+    const labels = Array.from(select.options).map((o) => o.textContent);
+    expect(labels).toContain("Firefox");
+    expect(labels.some((l) => l && l.includes("VSCode"))).toBe(false);
+  });
+
+  it("openWith dropdown keeps non-browser apps on file/folder rows", async () => {
+    // file/folder podem ser abertos por qualquer app — filtro só vale pra URL.
+    await renderEditor([{ kind: "file", value: "/tmp/x", openWith: "" }]);
+    await screen.findByRole("option", { name: "VSCode" });
+    const select = screen.getByTestId("item-open-with-0") as HTMLSelectElement;
+    const labels = Array.from(select.options).map((o) => o.textContent);
+    expect(labels).toContain("Firefox");
+    expect(labels).toContain("VSCode");
+  });
+
   it("renders the existing openWith value (custom value preserved as synthetic option)", async () => {
     await renderEditor([
       { kind: "url", value: "https://w", openWith: "edge" },

--- a/src/settings/__tests__/ItemListEditor.test.tsx
+++ b/src/settings/__tests__/ItemListEditor.test.tsx
@@ -205,6 +205,89 @@ describe("ItemListEditor", () => {
     ]);
   });
 
+  it("renders a header row with column labels when values is non-empty", async () => {
+    await renderEditor([{ kind: "url", value: "https://a", openWith: "" }]);
+    const header = screen.getByTestId("item-header-row");
+    expect(header).toBeTruthy();
+    expect(header.textContent).toMatch(/tipo/i);
+    expect(header.textContent).toMatch(/valor/i);
+    expect(header.textContent).toMatch(/abrir com/i);
+  });
+
+  it("does not render the header row when values is empty", async () => {
+    await renderEditor([]);
+    expect(screen.queryByTestId("item-header-row")).toBeNull();
+  });
+
+  it("hides 'Abrir com' header when no row uses openWith", async () => {
+    await renderEditor([
+      { kind: "app", value: "firefox", openWith: "" },
+      { kind: "script", value: "ls", openWith: "", trusted: false },
+    ]);
+    const header = screen.getByTestId("item-header-row");
+    expect(header.textContent).not.toMatch(/abrir com/i);
+  });
+
+  it("shows monitor header when 2+ monitors are connected", async () => {
+    await renderEditor(
+      [{ kind: "url", value: "https://a", openWith: "" }],
+      [
+        {
+          name: "Tela 1",
+          index: 0,
+          x: 0,
+          y: 0,
+          width: 1920,
+          height: 1080,
+          primary: true,
+        },
+        {
+          name: "Tela 2",
+          index: 1,
+          x: 1920,
+          y: 0,
+          width: 1280,
+          height: 720,
+          primary: false,
+        },
+      ],
+    );
+    const header = screen.getByTestId("item-header-row");
+    expect(header.textContent).toMatch(/tela/i);
+  });
+
+  it("openWith dropdown title-cases option labels on URL rows only", async () => {
+    const i18n = await createI18n("pt-BR");
+    const apps = [
+      { name: "google chrome", value: "chrome", path: "/usr/bin/chrome" },
+      { name: "FIREFOX", value: "firefox", path: "/usr/bin/firefox" },
+    ];
+    const { rerender } = render(
+      <I18nextProvider i18n={i18n}>
+        <ItemListEditor
+          values={[{ kind: "url", value: "https://a", openWith: "" }]}
+          onChange={vi.fn()}
+          installedAppsOverride={apps}
+        />
+      </I18nextProvider>,
+    );
+    await screen.findByRole("option", { name: "Google Chrome" });
+    expect(screen.getByRole("option", { name: "Firefox" })).toBeTruthy();
+
+    // file row — labels preservam o nome bruto (sem titleCase).
+    rerender(
+      <I18nextProvider i18n={i18n}>
+        <ItemListEditor
+          values={[{ kind: "file", value: "/tmp/x", openWith: "" }]}
+          onChange={vi.fn()}
+          installedAppsOverride={apps}
+        />
+      </I18nextProvider>,
+    );
+    expect(screen.getByRole("option", { name: "google chrome" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "FIREFOX" })).toBeTruthy();
+  });
+
   it("openWith dropdown filters to browsers only on URL rows", async () => {
     // Mock global retorna Firefox + VSCode. URL row deve mostrar só Firefox
     // (browser); VSCode some.
@@ -218,6 +301,8 @@ describe("ItemListEditor", () => {
 
   it("openWith dropdown keeps non-browser apps on file/folder rows", async () => {
     // file/folder podem ser abertos por qualquer app — filtro só vale pra URL.
+    // titleCase também é só pra URL — nomes nativos preservados aqui (VSCode
+    // mantém caps internos).
     await renderEditor([{ kind: "file", value: "/tmp/x", openWith: "" }]);
     await screen.findByRole("option", { name: "VSCode" });
     const select = screen.getByTestId("item-open-with-0") as HTMLSelectElement;

--- a/src/settings/__tests__/ItemListEditor.test.tsx
+++ b/src/settings/__tests__/ItemListEditor.test.tsx
@@ -256,6 +256,47 @@ describe("ItemListEditor", () => {
     expect(header.textContent).toMatch(/tela/i);
   });
 
+  // ---- Issue: incognito toggle ----
+
+  it("incognito toggle renders for URL rows only", async () => {
+    await renderEditor([
+      { kind: "url", value: "https://a", openWith: "Firefox" },
+      { kind: "file", value: "/tmp/x", openWith: "" },
+      { kind: "app", value: "firefox", openWith: "" },
+    ]);
+    expect(screen.getByTestId("item-incognito-0")).toBeTruthy();
+    expect(screen.queryByTestId("item-incognito-1")).toBeNull();
+    expect(screen.queryByTestId("item-incognito-2")).toBeNull();
+  });
+
+  it("incognito checkbox enabled regardless of openWith (detection at launch)", async () => {
+    await renderEditor([
+      { kind: "url", value: "https://a", openWith: "" },
+    ]);
+    const cb = screen.getByTestId("item-incognito-0") as HTMLInputElement;
+    expect(cb.disabled).toBe(false);
+  });
+
+  it("toggling incognito emits onChange with the new flag (no openWith)", async () => {
+    const { onChange } = await renderEditor([
+      { kind: "url", value: "https://a", openWith: "" },
+    ]);
+    fireEvent.click(screen.getByTestId("item-incognito-0"));
+    expect(onChange).toHaveBeenLastCalledWith([
+      { kind: "url", value: "https://a", openWith: "", incognito: true },
+    ]);
+  });
+
+  it("toggling incognito emits onChange with the new flag (with openWith)", async () => {
+    const { onChange } = await renderEditor([
+      { kind: "url", value: "https://a", openWith: "Firefox" },
+    ]);
+    fireEvent.click(screen.getByTestId("item-incognito-0"));
+    expect(onChange).toHaveBeenLastCalledWith([
+      { kind: "url", value: "https://a", openWith: "Firefox", incognito: true },
+    ]);
+  });
+
   it("openWith dropdown title-cases option labels on URL rows only", async () => {
     const i18n = await createI18n("pt-BR");
     const apps = [

--- a/src/settings/__tests__/ProfileEditor.test.tsx
+++ b/src/settings/__tests__/ProfileEditor.test.tsx
@@ -58,7 +58,11 @@ describe("ProfileEditor", () => {
     const user = userEvent.setup();
     const { props } = await renderEditor();
     await user.type(screen.getByLabelText(/nome/i), "Trabalho");
-    await user.type(screen.getByLabelText(/ícone/i), "📚");
+    // Empty state shows input; após change vira chip — usar fireEvent pra
+    // setar emoji surrogate-pair em single shot.
+    fireEvent.change(screen.getByTestId("profile-icon"), {
+      target: { value: "📚" },
+    });
     await user.click(screen.getByRole("button", { name: /^criar$/i }));
     expect(props.onSubmit).toHaveBeenCalledWith({
       name: "Trabalho",
@@ -91,7 +95,10 @@ describe("ProfileEditor", () => {
     expect((screen.getByLabelText(/nome/i) as HTMLInputElement).value).toBe(
       "Trabalho",
     );
-    expect((screen.getByLabelText(/ícone/i) as HTMLInputElement).value).toBe("💼");
+    // Icon prefilled → chip mode (input não renderiza).
+    expect(screen.queryByTestId("profile-icon")).toBeNull();
+    const chip = screen.getByTestId("profile-icon-chip");
+    expect(chip.textContent).toContain("💼");
     expect(screen.getByRole("button", { name: /^salvar$/i })).toBeTruthy();
   });
 
@@ -105,8 +112,8 @@ describe("ProfileEditor", () => {
   it("clears icon to null when edit mode wipes the field", async () => {
     const user = userEvent.setup();
     const { props } = await renderEditor({ mode: "edit", initial: existing });
-    const iconInput = screen.getByLabelText(/ícone/i) as HTMLInputElement;
-    await user.clear(iconInput);
+    // Chip mode (icon "💼" prefilled). Clear via X button.
+    fireEvent.click(screen.getByTestId("profile-icon-chip-clear"));
     await user.click(screen.getByRole("button", { name: /^salvar$/i }));
     expect(props.onSubmit).toHaveBeenCalledWith({
       name: "Trabalho",
@@ -206,8 +213,8 @@ describe("ProfileEditor", () => {
     expect(
       (screen.getByLabelText(/nome/i) as HTMLInputElement).value,
     ).toBe("Estudo");
-    expect(
-      (screen.getByLabelText(/ícone/i) as HTMLInputElement).value,
-    ).toBe("📚");
+    // Icon "📚" prefilled após troca → chip mode.
+    expect(screen.queryByTestId("profile-icon")).toBeNull();
+    expect(screen.getByTestId("profile-icon-chip").textContent).toContain("📚");
   });
 });

--- a/src/settings/__tests__/TabEditor.test.tsx
+++ b/src/settings/__tests__/TabEditor.test.tsx
@@ -33,7 +33,7 @@ const existing: Tab = {
   icon: "💼",
   order: 0,
   openMode: "reuseOrNewWindow",
-  items: [{ kind: "url", value: "https://example.com", openWith: null, monitor: null }],
+  items: [{ kind: "url", value: "https://example.com", openWith: null, monitor: null , incognito: false}],
   kind: "leaf",
   children: [],
 };
@@ -198,7 +198,7 @@ describe("TabEditor", () => {
     expect(props.onSave).toHaveBeenCalledTimes(1);
     const payload = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as Tab;
     expect(payload.items).toEqual([
-      { kind: "url", value: "https://a.test", openWith: null, monitor: null },
+      { kind: "url", value: "https://a.test", openWith: null, monitor: null , incognito: false},
       { kind: "file", path: "C:/x.txt", openWith: null, monitor: null },
       { kind: "folder", path: "/tmp", openWith: null, monitor: null },
     ]);
@@ -236,7 +236,7 @@ describe("TabEditor", () => {
     expect(props.onSave).toHaveBeenCalledTimes(1);
     const payload = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as Tab;
     expect(payload.items).toEqual([
-      { kind: "url", value: "https://kept.test", openWith: null, monitor: null },
+      { kind: "url", value: "https://kept.test", openWith: null, monitor: null , incognito: false},
     ]);
   });
 
@@ -246,7 +246,7 @@ describe("TabEditor", () => {
     const tabWithOpenWith: Tab = {
       ...existing,
       items: [
-        { kind: "url", value: "https://work.test", openWith: "firefox", monitor: null },
+        { kind: "url", value: "https://work.test", openWith: "firefox", monitor: null , incognito: false},
       ],
     };
     const user = userEvent.setup();
@@ -254,15 +254,64 @@ describe("TabEditor", () => {
     await user.click(screen.getByRole("button", { name: /^salvar$/i }));
     const payload = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as Tab;
     expect(payload.items).toEqual([
-      { kind: "url", value: "https://work.test", openWith: "firefox", monitor: null },
+      { kind: "url", value: "https://work.test", openWith: "firefox", monitor: null , incognito: false},
     ]);
+  });
+
+  it("preserves incognito flag through save round-trip", async () => {
+    // Regressão: handleSubmit rebuilds drafts antes de draftToItem; campo
+    // `incognito` precisa ser carregado nessa rebuild senão o flag some.
+    const tab: Tab = {
+      ...existing,
+      items: [
+        {
+          kind: "url",
+          value: "https://x.test",
+          openWith: "Firefox",
+          monitor: null,
+          incognito: false,
+        },
+      ],
+    };
+    const user = userEvent.setup();
+    const { props } = await renderEditor({ mode: "edit", initial: tab });
+    fireEvent.click(screen.getByTestId("item-incognito-0"));
+    await user.click(screen.getByRole("button", { name: /^salvar$/i }));
+    const payload = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as Tab;
+    const first = payload.items[0];
+    if (first.kind !== "url") throw new Error("expected url item");
+    expect(first.incognito).toBe(true);
+  });
+
+  it("preserves incognito flag when openWith is empty (default browser path)", async () => {
+    const tab: Tab = {
+      ...existing,
+      items: [
+        {
+          kind: "url",
+          value: "https://x.test",
+          openWith: null,
+          monitor: null,
+          incognito: false,
+        },
+      ],
+    };
+    const user = userEvent.setup();
+    const { props } = await renderEditor({ mode: "edit", initial: tab });
+    fireEvent.click(screen.getByTestId("item-incognito-0"));
+    await user.click(screen.getByRole("button", { name: /^salvar$/i }));
+    const payload = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as Tab;
+    const first = payload.items[0];
+    if (first.kind !== "url") throw new Error("expected url item");
+    expect(first.incognito).toBe(true);
+    expect(first.openWith).toBeNull();
   });
 
   it("saves openWith as null when set back to default", async () => {
     const tabWithOpenWith: Tab = {
       ...existing,
       items: [
-        { kind: "url", value: "https://x.test", openWith: "firefox", monitor: null },
+        { kind: "url", value: "https://x.test", openWith: "firefox", monitor: null , incognito: false},
       ],
     };
     const user = userEvent.setup();
@@ -281,7 +330,7 @@ describe("TabEditor", () => {
     const tabWithOpenWith: Tab = {
       ...existing,
       items: [
-        { kind: "url", value: "https://a.test", openWith: "edge", monitor: null },
+        { kind: "url", value: "https://a.test", openWith: "edge", monitor: null , incognito: false},
       ],
     };
     await renderEditor({ mode: "edit", initial: tabWithOpenWith });

--- a/src/settings/__tests__/TabEditor.test.tsx
+++ b/src/settings/__tests__/TabEditor.test.tsx
@@ -71,7 +71,10 @@ describe("TabEditor", () => {
   it("saves a valid new tab with only-icon", async () => {
     const user = userEvent.setup();
     const { props } = await renderEditor();
-    await user.type(screen.getByLabelText(/ícone/i), "📝");
+    // Empty state mostra input; depois do change, IconField alterna pra chip.
+    fireEvent.change(screen.getByTestId("tab-icon"), {
+      target: { value: "📝" },
+    });
     await user.type(screen.getByLabelText(/url 1/i), "https://a.test");
     await user.click(screen.getByRole("button", { name: /^salvar$/i }));
     expect(props.onSave).toHaveBeenCalledTimes(1);
@@ -84,7 +87,10 @@ describe("TabEditor", () => {
   it("prefills fields when editing an existing tab", async () => {
     await renderEditor({ mode: "edit", initial: existing });
     expect((screen.getByLabelText(/nome/i) as HTMLInputElement).value).toBe("Trabalho");
-    expect((screen.getByLabelText(/ícone/i) as HTMLInputElement).value).toBe("💼");
+    // Icon prefilled → chip mode (input não renderiza).
+    expect(screen.queryByTestId("tab-icon")).toBeNull();
+    const chip = screen.getByTestId("tab-icon-chip");
+    expect(chip.textContent).toContain("💼");
     expect((screen.getByLabelText(/url 1/i) as HTMLInputElement).value).toBe(
       "https://example.com",
     );
@@ -152,9 +158,13 @@ describe("TabEditor", () => {
 
   it("strips letters but keeps emoji when the value is set from a paste", async () => {
     await renderEditor();
-    const iconInput = screen.getByLabelText(/ícone/i) as HTMLInputElement;
+    const iconInput = screen.getByTestId("tab-icon") as HTMLInputElement;
     fireEvent.change(iconInput, { target: { value: "💼Work" } });
-    expect(iconInput.value).toBe("💼");
+    // stripLetters preserva o emoji; resultante non-empty → IconField vira chip.
+    expect(screen.queryByTestId("tab-icon")).toBeNull();
+    const chip = screen.getByTestId("tab-icon-chip");
+    expect(chip.textContent).toContain("💼");
+    expect(chip.textContent).not.toContain("Work");
   });
 
   it("keeps non-letter symbols like '★' and '→'", async () => {


### PR DESCRIPTION
## Resumo

Batch 5 de fixes/melhorias agrupando 7 commits sobre Settings UI, AppPicker no Windows e nova feature de URL anônima.

## Mudanças

### Settings UI
- **`fix(settings)`**: encolher select "Abrir com" (180→150px) e filtrar lista pra navegadores quando `kind: "url"` (match via `isBrowser` contra keywords conhecidos); file/folder mantêm lista completa.
- **`feat(settings)`**: header de colunas em `<ItemListEditor>` (Tipo/Valor/Abrir com/Tela) com slot fixo 130px reservado pra browse/app-picker mantendo alinhamento; `VALUE_MIN_WIDTH = 200`; openWith 200px; titleCase nos labels de browser.
- **`feat(settings)`**: novo `<IconDisplay>` (análogo HTML do `<IconRenderer>` SVG) resolvendo `lucide:Name` → SVG, image refs → `<img>`, emoji/texto → `<span>`. Substitui token literal em `<DraggableProfileList>`, `<ProfilesSection>`, `<TabList>`; preview 28×28 ao lado do input em `<TabEditor>`/`<ProfileEditor>`.
- **`feat(settings)`**: novo `<IconField>` unifica input + preview de ícone em `<TabEditor>` e `<ProfileEditor>` — empty state mostra input compacto (90px, font 20px); non-empty state vira chip 80×40 com `<IconDisplay>`. Click no chip reabre picker, × limpa. `stripLetters` aplicado internamente; tokens `lucide:` bypassam o strip.
- **`fix(settings)`**: remover heading duplicado em `<UpdateCard>` (já está dentro de fieldset com `<legend>` "Atualizações"). Chave morta `settings.system.update.heading` deletada dos locales.

### Donut
- **`fix(donut)`**: `<ProfileSwitcher>` agora renderiza ícones via `iconNode={<IconRenderer/>}` em vez de passar `icon` string crua — tokens `lucide:Name` resolvem em vez de aparecer literais nas fatias de perfil. Fonte do donut migra do default SVG (serif) pra stack `system sans-serif` aplicada via `style.fontFamily` nas duas roots `<svg>`.

### AppPicker (Windows) — Issue #48
- **`feat(apps_picker)`**: ampliar varredura + cache em disco.
  - Scan da chave `Uninstall` do registry (HKLM + HKCU + WOW6432Node) pra catch apps GUI sem entry em `App Paths`. Helper puro `uninstall_entry_to_installed` filtra `SystemComponent=1` e `ParentKeyName` non-empty; resolve `value` via `DisplayIcon` (strip índice) ou `InstallLocation` como fallback.
  - Parse de `.lnk` target via crate `parselnk` (cfg-windows): `lnk_path_to_installed` extrai o `.exe` real do shortcut, com fallback ao path do `.lnk` (launcher rota via ShellExecute como antes).
  - Cache JSON `<app_config>/apps_cache.json` com TTL 7 dias; `load_or_refresh(path, force, fetcher)` orquestra read+refresh atômico (tmp+rename). Botão "Atualizar lista" no `<AppPicker>` força refresh via novo flag `listInstalledApps(force=false)`.

### URL Incognito (nova feature)
- **`feat(launcher)`**: checkbox "Anônima" por URL no editor de abas; launcher invoca o navegador em modo privado via flag CLI específico.
  - Schema: `Item::Url.incognito: bool` (`#[serde(default, skip_serializing_if = is_default_bool)]`) — configs anteriores deserializam como `false`. Round-trip preservado no `<TabEditor>`.
  - Launcher: novo `Opener::open_url_incognito(url, browser)` com default impl delegando ao `open_url` (testes). `TauriOpener` override usa `std::process::Command` direto (bypassa scope do plugin-shell). Helper puro `browser_incognito_flag(name)` mapeia case-insensitive: `--incognito` (Chromium), `-private-window` (Firefox/forks), `--inprivate` (Edge), `--private` (Opera).
  - Detecção de default browser quando `openWith` vazio + `incognito=true`, novo módulo `default_browser/`:
    - **Windows**: `AssocQueryStringW` (FFI inline pra shlwapi.dll) — consulta o handler real do Windows shell, cobrindo Microsoft Store apps + Default Apps Settings (ao contrário de leitura raw do registry UserChoice, que dessincroniza quando Opera GX/outros hijackam). Fallback chain: UserChoice ProgId → `HKCR`/`HKCU`/`HKLM\Classes` → `StartMenuInternet` com loose match.
    - **Linux**: `xdg-settings get default-web-browser` → resolve `.desktop` em paths XDG, parseia `Exec=` via `apps_picker::linux::parse_desktop_entry`. Cobre Flatpak/Snap.
    - **macOS**: `LSCopyDefaultApplicationURLForURL` (Launch Services via `core-foundation` + FFI pra CoreServices). Extrai bundle display name; fallback probe `/Applications/` por bundles conhecidos.
  - Frontend: checkbox por linha de URL no `<ItemListEditor>` após Monitor select. Tooltip explica o modo e o comportamento "Padrão do sistema".

## Cobertura de testes
- 8 launcher Rust (5 flag mapping + 3 dispatch routes incognito)
- 3 validação incognito
- 7 Windows (`parse_command_exe` + `normalize_loose`)
- 5 Linux `resolve_desktop_exec` (gated `cfg(linux)`)
- 9 macOS `extract_bundle_name` + `probe_common_bundles`
- 13 apps_picker (6 uninstall + 7 cache)
- 5 frontend `<ItemListEditor>` + 2 `<TabEditor>` round-trip
- 6 settings (header row + browser titleCase + `<IconDisplay>`)
- 10 `<IconField>` + adaptações em `<TabEditor>`/`<ProfileEditor>`

## Issues abordadas
- #48 — AppPicker no Windows não encontrava muitos apps
- Bugs visuais diversos em ícones Lucide (literais aparecendo no donut e no Settings)
- Duplicação de título em `<UpdateCard>`

## Test plan
- [ ] `npm test` (frontend) e `cargo test --lib` (Rust) verdes
- [ ] Abrir uma URL com checkbox "Anônima" ligada em Chrome/Edge/Firefox sem `openWith` configurado (default detectado)
- [ ] Repetir com `openWith` forçado (Chrome, Firefox, Edge, Opera, Brave)
- [ ] AppPicker no Windows: lista populada via `Uninstall` registry + `.lnk` resolvendo `.exe`; botão "Atualizar lista" força refresh
- [ ] Ícones `lucide:Name` renderizando em: profile switcher no donut, `<TabList>`, `<ProfilesSection>`, `<DraggableProfileList>`
- [ ] `<IconField>`: chip aparece com value preenchido; click reabre picker; × volta pra input