### PR TITLE
Updater UX fix + release pipeline fix + v1.0.0

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -30,9 +30,15 @@ O comando pede uma senha. Anote — ela será o secret `TAURI_SIGNING_PRIVATE_KE
 
 ### 2. Configurar `tauri.conf.json`
 
-Substitua o placeholder em `src-tauri/tauri.conf.json`:
+Dois blocos precisam ficar certos no `src-tauri/tauri.conf.json`:
 
 ```jsonc
+"bundle": {
+  "active": true,
+  "targets": "all",
+  "createUpdaterArtifacts": true,   // OBRIGATÓRIO — ver nota abaixo
+  ...
+},
 "plugins": {
   "updater": {
     "endpoints": [
@@ -44,7 +50,9 @@ Substitua o placeholder em `src-tauri/tauri.conf.json`:
 }
 ```
 
-**Atenção:** essa pubkey é embarcada nos binários compilados a partir desse commit. Se a chave for trocada depois, **apps com versão antiga rejeitam updates assinados pela nova chave** — o usuário precisaria reinstalar manualmente. Trate a pubkey como decisão para a vida do projeto.
+**`bundle.createUpdaterArtifacts: true`** é a pegadinha do Tauri 2: o default é `false`, e sem ele a build não registra os bundles updater (`*.app.tar.gz` macOS, `*.AppImage.tar.gz` Linux, NSIS Windows) no JSON de output. Resultado: o `tauri-action` loga `Signature not found for the updater JSON. Skipping upload...` e pula o `latest.json` — release sai sem manifest e apps instalados nunca veem novas versões (mostram "Você está na versão mais recente" pra sempre). Aconteceu nos v0.1.0 e v0.1.1 antes de a flag ser adicionada.
+
+**Atenção pubkey:** essa pubkey é embarcada nos binários compilados a partir desse commit. Se a chave for trocada depois, **apps com versão antiga rejeitam updates assinados pela nova chave** — o usuário precisaria reinstalar manualmente. Trate a pubkey como decisão para a vida do projeto.
 
 ### 3. Configurar secrets no GitHub
 
@@ -143,8 +151,9 @@ Solução: confirme que a pubkey no commit do release-tag bate com a chave públ
 
 ### `latest.json` retorna 404
 
-Workflow não terminou ou falhou. Conferir aba **Actions** do repo. Comum em primeiros runs:
+Workflow não terminou ou falhou, **ou** o action pulou a publicação do manifest. Conferir aba **Actions** do repo:
 
+- **Mais comum:** logs dos jobs `Build *` mostram `Signature not found for the updater JSON. Skipping upload...`. Causa: `bundle.createUpdaterArtifacts` ausente ou `false` em `tauri.conf.json` — sem isso o Tauri 2 não gera os bundles updater registrados no JSON de output. Garanta que está `true` (setup §2).
 - Faltam dependências nativas no Linux (já cobertas em `release.yml`, mas se a versão do `webkit2gtk` mudar, ajustar `apt-get install`).
 - macOS sem Apple Dev Cert: build passa, signing local falha. Para v1 do projeto, build sem certs ainda gera bundles válidos para signature do updater (Tauri usa Ed25519 separado de code-signing OS).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tauri-app",
   "private": true,
-  "version": "0.1.1",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-app"
-version = "0.1.1"
+version = "1.0.0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-app"
-version = "0.1.1"
+version = "1.0.0"
 description = "DonutTabs — radial tab launcher triggered by a global shortcut"
 authors = ["Yuri Hemmel <yuri.modolin@helppi.com.br>"]
 edition = "2021"

--- a/src-tauri/src/updater/mod.rs
+++ b/src-tauri/src/updater/mod.rs
@@ -47,16 +47,19 @@ pub async fn check<R: Runtime>(handle: &AppHandle<R>) -> AppResult<Option<Update
             date: update.date.map(|d| d.to_string()),
         })),
         Ok(None) => Ok(None),
-        Err(e) if is_missing_manifest_error(&e) => Ok(None),
+        Err(e) if is_missing_manifest_error(&e) => {
+            eprintln!("[updater] no applicable manifest ({e}); treating as up-to-date");
+            Ok(None)
+        }
         Err(e) => Err(map_check_error(e)),
     }
 }
 
 /// `true` quando o erro do plugin significa "manifest não disponível"
-/// (404 no endpoint, JSON malformado em todos os endpoints, ou manifest
-/// presente sem o target atual). Do ponto de vista do usuário, nenhum
-/// desses casos é "sem conexão" — não há atualização aplicável, então
-/// `check()` os converte em `Ok(None)`.
+/// (404 no endpoint `latest.json`, ou manifest presente porém sem o target
+/// do SO/arch atual). Do ponto de vista do usuário, nenhum desses casos é
+/// "sem conexão" — não há atualização aplicável, então `check()` os
+/// converte em `Ok(None)`.
 pub(crate) fn is_missing_manifest_error(e: &PluginError) -> bool {
     matches!(
         e,

--- a/src-tauri/src/updater/mod.rs
+++ b/src-tauri/src/updater/mod.rs
@@ -47,8 +47,23 @@ pub async fn check<R: Runtime>(handle: &AppHandle<R>) -> AppResult<Option<Update
             date: update.date.map(|d| d.to_string()),
         })),
         Ok(None) => Ok(None),
+        Err(e) if is_missing_manifest_error(&e) => Ok(None),
         Err(e) => Err(map_check_error(e)),
     }
+}
+
+/// `true` quando o erro do plugin significa "manifest não disponível"
+/// (404 no endpoint, JSON malformado em todos os endpoints, ou manifest
+/// presente sem o target atual). Do ponto de vista do usuário, nenhum
+/// desses casos é "sem conexão" — não há atualização aplicável, então
+/// `check()` os converte em `Ok(None)`.
+pub(crate) fn is_missing_manifest_error(e: &PluginError) -> bool {
+    matches!(
+        e,
+        PluginError::ReleaseNotFound
+            | PluginError::TargetNotFound(_)
+            | PluginError::TargetsNotFound(_)
+    )
 }
 
 /// Baixa e instala a atualização atual, emitindo `UPDATE_PROGRESS_EVENT`
@@ -117,10 +132,7 @@ pub(crate) fn classify_check_error(e: &PluginError) -> &'static str {
         | PluginError::UrlParse(_)
         | PluginError::Http(_)
         | PluginError::InvalidHeaderName(_)
-        | PluginError::InvalidHeaderValue(_)
-        | PluginError::ReleaseNotFound
-        | PluginError::TargetNotFound(_)
-        | PluginError::TargetsNotFound(_) => "updater_network_unavailable",
+        | PluginError::InvalidHeaderValue(_) => "updater_network_unavailable",
         _ => "updater_check_failed",
     }
 }
@@ -162,19 +174,29 @@ mod tests {
     }
 
     #[test]
-    fn release_not_found_classified_as_network_unavailable() {
-        assert_eq!(
-            classify_check_error(&PluginError::ReleaseNotFound),
-            "updater_network_unavailable",
-        );
+    fn release_not_found_is_missing_manifest() {
+        assert!(is_missing_manifest_error(&PluginError::ReleaseNotFound));
     }
 
     #[test]
-    fn target_not_found_classified_as_network_unavailable() {
-        assert_eq!(
-            classify_check_error(&PluginError::TargetNotFound("darwin-x86_64".into())),
-            "updater_network_unavailable",
-        );
+    fn target_not_found_is_missing_manifest() {
+        assert!(is_missing_manifest_error(&PluginError::TargetNotFound(
+            "darwin-x86_64".into()
+        )));
+    }
+
+    #[test]
+    fn targets_not_found_is_missing_manifest() {
+        assert!(is_missing_manifest_error(&PluginError::TargetsNotFound(
+            vec!["darwin-x86_64".into()],
+        )));
+    }
+
+    #[test]
+    fn network_error_is_not_missing_manifest() {
+        assert!(!is_missing_manifest_error(&PluginError::Network(
+            "dns".into()
+        )));
     }
 
     #[test]
@@ -182,6 +204,18 @@ mod tests {
         // `UnsupportedArch` não é network nem signature — vira fallback.
         assert_eq!(
             classify_check_error(&PluginError::UnsupportedArch),
+            "updater_check_failed",
+        );
+    }
+
+    #[test]
+    fn release_not_found_falls_back_to_check_failed_if_reaches_classifier() {
+        // `check()` curto-circuita esse caso para `Ok(None)` via
+        // `is_missing_manifest_error`, então o classifier nunca deveria
+        // ver `ReleaseNotFound`. Mas se chegar (regressão), o fallback
+        // não-network é o comportamento defensivo correto.
+        assert_eq!(
+            classify_check_error(&PluginError::ReleaseNotFound),
             "updater_check_failed",
         );
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,6 +23,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tauri-app",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "identifier": "com.donuttabs.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Três commits empilhados pra desbloquear o auto-updater e marcar a v1.0:

1. **`fix(updater)`** — `check()` agora trata `ReleaseNotFound`/`TargetNotFound`/`TargetsNotFound` (sintomas de 404 no `latest.json` ou manifest sem o target atual) como `Ok(None)` em vez de `updater_network_unavailable`. UI mostra "Você está na versão mais recente" em vez do enganoso "Sem conexão para verificar atualizações".

2. **`fix(release)`** — habilita `bundle.createUpdaterArtifacts: true` em `tauri.conf.json`. Sem essa flag, Tauri 2 não registra os bundles updater (`.app.tar.gz` mac, `.AppImage.tar.gz` Linux, NSIS Windows) no JSON de output do build, então `tauri-action` pula a publicação do `latest.json` (root cause dos releases v0.1.0 e v0.1.1 saírem sem manifest). `docs/release-process.md` ganhou nota explícita + entrada no troubleshooting.

3. **`chore(release): v1.0.0`** — bump em `tauri.conf.json`, `Cargo.toml`, `package.json`, `Cargo.lock`.

## Test plan

- [x] `cargo test --lib updater` — 17 testes passam, incluindo 4 novos pro `is_missing_manifest_error`
- [x] `cargo test --lib` — 410 testes passam
- [x] `npx vitest run` — 450 testes passam
- [x] `cargo fmt --check` — limpo
- [ ] Após merge: criar e fazer push da tag `v1.0.0` anotada pra disparar o `release.yml`
- [ ] Verificar que o release publicado contém `latest.json` + bundles `.app.tar.gz`/`.AppImage.tar.gz`/NSIS
- [ ] Validar em app instalado v0.1.1 que detecta a v1.0.0 e oferece o update

🤖 Generated with [Claude Code](https://claude.com/claude-code)