### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "donuttabs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "donuttabs",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "donuttabs",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "donuttabs"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "donuttabs"
-version = "1.0.0"
+version = "1.1.0"
 description = "DonutTabs — radial tab launcher triggered by a global shortcut"
 authors = ["Yuri Hemmel <yuri.modolin@helppi.com.br>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DonutTabs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "identifier": "com.donuttabs.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Resumo

Bump de versão para `v1.1.0` em `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` (+ lockfiles).

Desde `v1.0.0` (#59) entraram:

- **#69** `chore(branding): renomear app pra DonutTabs e atualizar ícone` — `productName` correto no bundle/Dock/Start, bin de dev renomeado, ícones regerados, assets MSIX removidos.
- **#70** `Resolve issues #58, #60, #63, #64, #65`:
  - `fix(settings)`: tamanho mínimo da janela 720×520 → 960×640 (initial 1120×720) pra caber as 7 colunas do `<ItemListEditor>` (#65).
  - `fix(donut)`: gap angular no profile switcher em paridade com modo abas (#58).
  - `feat(scripts)`: seleção de shell por item Script (`cmd | powershell | pwsh | wsl | bash | sh | zsh`) + novo erro `script_shell_invalid` (#64).
  - `feat(scripts)`: modal de ajuda (`<ScriptHelpModal>`) com explicação de uso, avisos de segurança e exemplos por shell (#63).
  - `feat(settings)`: expansão inline de grupos na sidebar do Settings (toggle ▶/▼) (#60).

## Test plan

- [x] `cargo test --lib` — 421 passed
- [x] `npm test` (vitest) — 470 passed
- [x] `npx tsc --noEmit` — limpo
- [ ] Após merge: criar tag anotada `v1.1.0` e push pra disparar `release.yml`
- [ ] Smoke nos 3 OSes a partir do bundle gerado (vide `docs/qa-smoke.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)