### PR TITLE
fix(settings): retargetar editor pro perfil ativo + badge "Ativo" e lápis "Editando" (#76)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -122,6 +122,7 @@
       "activate": "Set as active profile",
       "activeMarker": "(active)",
       "activeBadge": "Active",
+      "editingMarker": "Editing",
       "sectionTitle": "Profiles",
       "addProfile": "Add profile",
       "selectPrompt": "Select a profile to edit or click \"+ Add profile\".",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -122,6 +122,7 @@
       "activate": "Definir como perfil ativo",
       "activeMarker": "(ativo)",
       "activeBadge": "Ativo",
+      "editingMarker": "Editando",
       "sectionTitle": "Perfis",
       "addProfile": "Adicionar perfil",
       "selectPrompt": "Selecione um perfil para editar ou clique em \"+ Adicionar perfil\".",

--- a/src/settings/DraggableProfileList.tsx
+++ b/src/settings/DraggableProfileList.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { Pencil } from "lucide-react";
 import type { Profile } from "../core/types/Profile";
 import { useDragReorder } from "./useDragReorder";
 import { IconDisplay } from "./IconDisplay";
@@ -108,14 +109,35 @@ export const DraggableProfileList: React.FC<DraggableProfileListProps> = ({
                 aria-label={t("settings.profile.activeMarker")}
                 title={t("settings.profile.activeMarker")}
                 style={{
-                  width: 8,
-                  height: 8,
-                  borderRadius: 999,
-                  background: "#f3c742",
                   marginLeft: 4,
-                  display: "inline-block",
+                  padding: "1px 6px",
+                  borderRadius: 999,
+                  background: "#3fb950",
+                  color: "#ffffff",
+                  fontSize: 10,
+                  fontWeight: 600,
+                  lineHeight: 1.4,
+                  textTransform: "uppercase",
+                  letterSpacing: 0.3,
                 }}
-              />
+              >
+                {t("settings.profile.activeBadge")}
+              </span>
+            )}
+            {isSelected && (
+              <span
+                data-testid={`profile-chip-editing-${p.id}`}
+                aria-label={t("settings.profile.editingMarker")}
+                title={t("settings.profile.editingMarker")}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  marginLeft: 4,
+                  color: "var(--muted)",
+                }}
+              >
+                <Pencil size={12} />
+              </span>
             )}
           </li>
         );

--- a/src/settings/ProfilePicker.tsx
+++ b/src/settings/ProfilePicker.tsx
@@ -19,7 +19,8 @@ export interface ProfilePickerProps {
  * "Aparência", "Atalho"). Issue #39: criação/edição/exclusão de perfis
  * mudaram pra a seção dedicada `<ProfilesSection>`. Aqui só ficam os chips
  * de seleção e o label. O perfil **ativo** (que comanda o donut) pode ser
- * diferente do **selecionado**; o marcador dourado sinaliza isso.
+ * diferente do **selecionado** (sob edição); um badge verde "Ativo" marca
+ * o primeiro e um ícone de lápis marca o segundo.
  */
 export const ProfilePicker: React.FC<ProfilePickerProps> = ({
   profiles,

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -141,6 +141,11 @@ export const SettingsApp: React.FC = () => {
   const configRef = useRef<Config | null>(config);
   configRef.current = config;
   const pendingIntentRef = useRef<string | null>(null);
+  // Issue #76 — guarda o último `activeProfileId` visto para detectar
+  // mudanças externas (donut, "definir como ativo" no Settings, import).
+  // `null` antes do primeiro config carregar; sincronizado pelo effect
+  // abaixo.
+  const prevActiveProfileIdRef = useRef<string | null>(null);
 
   const apply = (target: IntentTarget) => {
     setSection(target.section);
@@ -192,12 +197,24 @@ export const SettingsApp: React.FC = () => {
       const target = resolveIntent(pending, config);
       if (target) {
         apply(target);
+        prevActiveProfileIdRef.current = config.activeProfileId;
         return;
       }
     }
-    if (selectedProfileId === null) {
-      setSelectedProfileId(config.activeProfileId);
+    // Issue #76 — quando o perfil ativo muda externamente (donut, botão
+    // "definir como ativo", import), retargeta o editor pro novo ativo
+    // pra que a seção "Abas" mostre as abas certas. Usuário ainda pode
+    // selecionar manualmente outro perfil no picker depois — só sobrescreve
+    // quando `activeProfileId` realmente muda entre snapshots.
+    const prev = prevActiveProfileIdRef.current;
+    const next = config.activeProfileId;
+    if (prev !== null && prev !== next) {
+      setSelectedProfileId(next);
+      setSelection({ mode: "empty" });
+    } else if (selectedProfileId === null) {
+      setSelectedProfileId(next);
     }
+    prevActiveProfileIdRef.current = next;
   }, [config]);
 
   // Issue #39 — se o perfil sob edição sumiu do config (ex: outra janela

--- a/src/settings/__tests__/DraggableProfileList.test.tsx
+++ b/src/settings/__tests__/DraggableProfileList.test.tsx
@@ -128,7 +128,7 @@ describe("DraggableProfileList", () => {
     expect(props.onSelect).toHaveBeenCalledWith("p2");
   });
 
-  it("active profile shows the gold marker", async () => {
+  it("active profile shows the 'Ativo' badge", async () => {
     await renderList({
       profiles: [
         profile({ id: "p1" }),
@@ -136,8 +136,23 @@ describe("DraggableProfileList", () => {
       ],
       activeId: "p2",
     });
-    expect(screen.getByTestId("profile-chip-active-p2")).toBeTruthy();
+    const badge = screen.getByTestId("profile-chip-active-p2");
+    expect(badge).toBeTruthy();
+    expect(badge.textContent).toMatch(/ativo/i);
     expect(screen.queryByTestId("profile-chip-active-p1")).toBeNull();
+  });
+
+  it("selected profile shows the editing pencil marker", async () => {
+    await renderList({
+      profiles: [
+        profile({ id: "p1" }),
+        profile({ id: "p2", name: "Estudo" }),
+      ],
+      selectedId: "p2",
+      activeId: "p1",
+    });
+    expect(screen.getByTestId("profile-chip-editing-p2")).toBeTruthy();
+    expect(screen.queryByTestId("profile-chip-editing-p1")).toBeNull();
   });
 
   it("dragging chip p1 over the right half of chip p2 emits onReorder([p2, p1])", async () => {

--- a/src/settings/__tests__/ProfilePicker.test.tsx
+++ b/src/settings/__tests__/ProfilePicker.test.tsx
@@ -56,7 +56,7 @@ describe("ProfilePicker", () => {
     expect(screen.getByTestId("profile-chip-p2")).toBeTruthy();
   });
 
-  it("active profile shows the gold marker", async () => {
+  it("active profile shows the 'Ativo' badge", async () => {
     await renderPicker({
       profiles: [
         profile({ id: "p1", name: "Padrão" }),
@@ -65,8 +65,23 @@ describe("ProfilePicker", () => {
       selectedId: "p1",
       activeId: "p2",
     });
-    expect(screen.getByTestId("profile-chip-active-p2")).toBeTruthy();
+    const badge = screen.getByTestId("profile-chip-active-p2");
+    expect(badge).toBeTruthy();
+    expect(badge.textContent).toMatch(/ativo/i);
     expect(screen.queryByTestId("profile-chip-active-p1")).toBeNull();
+  });
+
+  it("selected profile shows the editing pencil marker", async () => {
+    await renderPicker({
+      profiles: [
+        profile({ id: "p1", name: "Padrão" }),
+        profile({ id: "p2", name: "Estudo" }),
+      ],
+      selectedId: "p1",
+      activeId: "p2",
+    });
+    expect(screen.getByTestId("profile-chip-editing-p1")).toBeTruthy();
+    expect(screen.queryByTestId("profile-chip-editing-p2")).toBeNull();
   });
 
   it("calls onSelect when a chip is clicked", async () => {

--- a/src/settings/__tests__/SettingsApp.test.tsx
+++ b/src/settings/__tests__/SettingsApp.test.tsx
@@ -702,6 +702,123 @@ describe("SettingsApp intent routing", () => {
     });
   });
 
+  it("issue #76: switching active profile via config-changed retargets the tabs section to the new active profile", async () => {
+    // Regressão: usuário trocava o perfil ativo pelo donut (ou via "definir
+    // como ativo"), mas a aba "Abas" continuava mostrando as abas do perfil
+    // anterior porque `selectedProfileId` ficava preso. Agora `activeProfileId`
+    // mudando entre snapshots força o editor a seguir.
+    const cfgA = makeConfig({
+      activeProfileId: PROFILE_ID,
+      profiles: [
+        makeProfile({
+          tabs: [
+            {
+              id: "t-a",
+              name: "AbaA",
+              icon: null,
+              order: 0,
+              openMode: "reuseOrNewWindow",
+              items: [{ kind: "url", value: "https://a.test" }],
+            },
+          ],
+        }),
+        makeProfile({
+          id: PROFILE_ID_2,
+          name: "Estudo",
+          tabs: [
+            {
+              id: "t-b",
+              name: "AbaB",
+              icon: null,
+              order: 0,
+              openMode: "reuseOrNewWindow",
+              items: [{ kind: "url", value: "https://b.test" }],
+            },
+          ],
+        }),
+      ],
+    });
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(cfgA);
+    await renderApp();
+    await waitFor(() => {
+      expect(screen.getByText("AbaA")).toBeTruthy();
+    });
+    const cfgB = { ...cfgA, activeProfileId: PROFILE_ID_2 };
+    act(() => {
+      (events as unknown as { __emit: (n: string, p: unknown) => void }).__emit(
+        "config-changed",
+        cfgB,
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText("AbaB")).toBeTruthy();
+      expect(screen.queryByText("AbaA")).toBeNull();
+    });
+    expect(
+      screen.getByTestId(`profile-chip-${PROFILE_ID_2}`).getAttribute(
+        "aria-selected",
+      ),
+    ).toBe("true");
+  });
+
+  it("issue #76: manual profile picks are not undone by unrelated config-changed events", async () => {
+    // Garante que a lógica de "seguir activeProfileId" não pisa em cima da
+    // escolha manual quando o config-changed não mexe no perfil ativo
+    // (ex: usuário salvou uma aba enquanto editava perfil inativo).
+    const cfg = makeConfig({
+      activeProfileId: PROFILE_ID,
+      profiles: [
+        makeProfile({
+          tabs: [
+            {
+              id: "t-a",
+              name: "AbaA",
+              icon: null,
+              order: 0,
+              openMode: "reuseOrNewWindow",
+              items: [{ kind: "url", value: "https://a.test" }],
+            },
+          ],
+        }),
+        makeProfile({
+          id: PROFILE_ID_2,
+          name: "Estudo",
+          tabs: [
+            {
+              id: "t-b",
+              name: "AbaB",
+              icon: null,
+              order: 0,
+              openMode: "reuseOrNewWindow",
+              items: [{ kind: "url", value: "https://b.test" }],
+            },
+          ],
+        }),
+      ],
+    });
+    (ipc.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(cfg);
+    const user = userEvent.setup();
+    await renderApp();
+    await waitFor(() => {
+      expect(screen.getByText("AbaA")).toBeTruthy();
+    });
+    await user.click(screen.getByTestId(`profile-chip-${PROFILE_ID_2}`));
+    await waitFor(() => {
+      expect(screen.getByText("AbaB")).toBeTruthy();
+    });
+    // config-changed sem alterar activeProfileId não deve voltar pra A.
+    act(() => {
+      (events as unknown as { __emit: (n: string, p: unknown) => void }).__emit(
+        "config-changed",
+        { ...cfg },
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText("AbaB")).toBeTruthy();
+    });
+    expect(screen.queryByText("AbaA")).toBeNull();
+  });
+
   it("AppearanceSection shows the set-active button only when editing a non-active profile", async () => {
     const cfg = makeConfig({
       profiles: [


### PR DESCRIPTION
Closes #76.

## Summary

- **Bug fix (#76)**: trocar o perfil ativo (via donut ou botão "definir como ativo") agora reflete na seção "Abas" do Settings. Antes o `selectedProfileId` era inicializado uma única vez no mount e nunca seguia mudanças externas de `activeProfileId`, deixando o editor preso no perfil anterior.
- **Visual da chip de perfil**: a bolinha (antes dourada, depois verde) virou um badge `Ativo` verde mais auto-explicativo; um lápis Lucide marca o perfil sob edição. Quando o perfil ativo também está sendo editado, ambos aparecem na ordem nome → badge → lápis.

## Arquivos relevantes

- `src/settings/SettingsApp.tsx` — `prevActiveProfileIdRef` detecta mudanças entre snapshots de config e retargeta `selectedProfileId` + reseta `selection`. Selecionar manualmente outro perfil no picker continua funcionando — só sobrescreve quando `activeProfileId` realmente muda.
- `src/settings/DraggableProfileList.tsx` — badge "Ativo" + ícone `Pencil` (lucide-react).
- `src/locales/{pt-BR,en}.json` — nova chave `settings.profile.editingMarker`.

## Test plan

- [x] `npx vitest run` — 481 testes passando, incluindo 4 novos:
  - `issue #76: switching active profile via config-changed retargets the tabs section`
  - `issue #76: manual profile picks are not undone by unrelated config-changed events`
  - `DraggableProfileList: selected profile shows the editing pencil marker`
  - `ProfilePicker: selected profile shows the editing pencil marker`
- [x] `npx tsc --noEmit` limpo.
- [ ] Smoke manual: trocar perfil ativo no donut e confirmar que a seção "Abas" no Settings atualiza.
- [ ] Smoke manual: confirmar que o lápis aparece no perfil em edição e o badge "Ativo" no ativo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)