### PR TITLE
feat(donut): modo rápido + hover-to-expand de grupos (#71)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -708,6 +708,31 @@ pub(crate) fn apply_set_slice_gap_enabled(cfg: &mut Config, enabled: bool) {
     cfg.interaction.slice_gap_enabled = enabled;
 }
 
+/// Issue #71 — toggle do "modo rápido". `true` = donut só fica visível
+/// enquanto o atalho está pressionado e abre a aba sob o cursor ao soltar;
+/// `false` = comportamento click-to-open clássico. Persiste + emite
+/// `CONFIG_CHANGED_EVENT`.
+#[tauri::command]
+pub fn set_quick_mode<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    enabled: bool,
+) -> Result<Config, AppError> {
+    let snapshot = {
+        let mut cfg = state.config.write().unwrap();
+        apply_set_quick_mode(&mut cfg, enabled);
+        save_with_rollback(&mut cfg, &state.config_path)?;
+        cfg.clone()
+    };
+    let _ = app.emit(CONFIG_CHANGED_EVENT, &snapshot);
+    Ok(snapshot)
+}
+
+/// Issue #71 — helper puro pra mutar `Config.interaction.quick_mode`.
+pub(crate) fn apply_set_quick_mode(cfg: &mut Config, enabled: bool) {
+    cfg.interaction.quick_mode = enabled;
+}
+
 /// Issue #52 — toggle entre `Cursor` (donut nasce na posição do mouse) e
 /// `Center` (centro do monitor onde o cursor está). Persiste + emite
 /// `CONFIG_CHANGED_EVENT`. A próxima abertura do donut respeita o novo
@@ -2815,6 +2840,17 @@ mod tests {
         assert!(!cfg.interaction.slice_gap_enabled);
         apply_set_slice_gap_enabled(&mut cfg, true);
         assert!(cfg.interaction.slice_gap_enabled);
+    }
+
+    #[test]
+    fn apply_set_quick_mode_toggles_flag() {
+        let mut cfg = Config::default();
+        // Default = false.
+        assert!(!cfg.interaction.quick_mode);
+        apply_set_quick_mode(&mut cfg, true);
+        assert!(cfg.interaction.quick_mode);
+        apply_set_quick_mode(&mut cfg, false);
+        assert!(!cfg.interaction.quick_mode);
     }
 
     #[test]

--- a/src-tauri/src/config/migrate.rs
+++ b/src-tauri/src/config/migrate.rs
@@ -70,6 +70,7 @@ mod tests {
                 hover_hold_ms: 800,
                 search_shortcut: "CommandOrControl+F".into(),
                 slice_gap_enabled: true,
+                quick_mode: false,
             },
             pagination: Pagination {
                 items_per_page: 6,

--- a/src-tauri/src/config/schema.rs
+++ b/src-tauri/src/config/schema.rs
@@ -134,6 +134,14 @@ pub struct Interaction {
     /// graças ao `#[serde(default = "default_slice_gap_enabled")]`.
     #[serde(default = "default_slice_gap_enabled")]
     pub slice_gap_enabled: bool,
+    /// Issue #71 — "modo rápido". Quando `true`, o donut só fica visível
+    /// enquanto o atalho global estiver pressionado: soltar a tecla abre
+    /// a aba sob o cursor (se houver) e esconde o donut. Default `false`
+    /// preserva o comportamento click-to-open. Configs anteriores
+    /// deserializam como `false` graças ao
+    /// `#[serde(default)]` (bool default). Wire: `quickMode` (camelCase).
+    #[serde(default)]
+    pub quick_mode: bool,
 }
 
 fn default_search_shortcut() -> String {
@@ -395,6 +403,7 @@ impl Default for Config {
                 hover_hold_ms: 1200,
                 search_shortcut: default_search_shortcut(),
                 slice_gap_enabled: default_slice_gap_enabled(),
+                quick_mode: false,
             },
             pagination: Pagination {
                 items_per_page: 6,
@@ -1035,11 +1044,51 @@ mod tests {
             hover_hold_ms: 1200,
             search_shortcut: "CommandOrControl+F".into(),
             slice_gap_enabled: false,
+            quick_mode: false,
         };
         let json = serde_json::to_string(&i).unwrap();
         assert!(json.contains("\"sliceGapEnabled\":false"));
         let back: Interaction = serde_json::from_str(&json).unwrap();
         assert_eq!(i, back);
+    }
+
+    // ---------- Issue #71: Interaction.quick_mode ----------
+
+    #[test]
+    fn interaction_defaults_quick_mode_to_false_when_absent() {
+        // Configs anteriores à #71 não têm o campo. Precisa virar `false`
+        // (preserva comportamento click-to-open).
+        let json = r#"{
+            "spawnPosition": "cursor",
+            "selectionMode": "clickOrRelease",
+            "hoverHoldMs": 1200,
+            "searchShortcut": "CommandOrControl+F",
+            "sliceGapEnabled": true
+        }"#;
+        let i: Interaction = serde_json::from_str(json).unwrap();
+        assert!(!i.quick_mode);
+    }
+
+    #[test]
+    fn interaction_round_trip_with_quick_mode_enabled() {
+        let i = Interaction {
+            spawn_position: SpawnPosition::Cursor,
+            selection_mode: SelectionMode::ClickOrRelease,
+            hover_hold_ms: 1200,
+            search_shortcut: "CommandOrControl+F".into(),
+            slice_gap_enabled: true,
+            quick_mode: true,
+        };
+        let json = serde_json::to_string(&i).unwrap();
+        assert!(json.contains("\"quickMode\":true"));
+        let back: Interaction = serde_json::from_str(&json).unwrap();
+        assert_eq!(i, back);
+    }
+
+    #[test]
+    fn default_config_has_quick_mode_disabled() {
+        let cfg = Config::default();
+        assert!(!cfg.interaction.quick_mode);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -253,6 +253,7 @@ pub fn run() {
             commands::import_config,
             commands::set_search_shortcut,
             commands::set_slice_gap_enabled,
+            commands::set_quick_mode,
             commands::set_spawn_position,
             commands::set_script_trusted,
             commands::set_profile_allow_scripts,

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -1,8 +1,13 @@
 use crate::donut_window;
 use crate::errors::{AppError, AppResult};
 use std::sync::Mutex;
-use tauri::{AppHandle, Runtime};
+use tauri::{AppHandle, Emitter, Manager, Runtime};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
+
+/// Issue #71 — evento emitido para a janela `donut` quando o atalho global
+/// é solto e `interaction.quick_mode` está ligado. O frontend do donut
+/// decide o que fazer (abre a aba sob o cursor + esconde, ou só esconde).
+pub const SHORTCUT_RELEASED_EVENT: &str = "shortcut-released";
 
 /// Estado do atalho global ativo. Vive em `AppState` e é consultado pelo
 /// comando `set_shortcut` para fazer o swap conflict-aware (registra o novo
@@ -102,9 +107,21 @@ mod tests {
 fn bind<R: Runtime>(app: &AppHandle<R>, sc: &Shortcut) -> AppResult<()> {
     let app_for_handler = app.clone();
     app.global_shortcut()
-        .on_shortcut(*sc, move |_app, _sc, event| {
-            if event.state() == ShortcutState::Pressed {
+        .on_shortcut(*sc, move |_app, _sc, event| match event.state() {
+            ShortcutState::Pressed => {
                 let _ = donut_window::show(&app_for_handler);
+            }
+            ShortcutState::Released => {
+                // Issue #71 — emitir só quando o usuário optou pelo modo
+                // quick_mode. Lê config via AppState; falha em pegar o
+                // state (cenário raro de setup parcial) é silenciada — o
+                // atalho já funcionou no Pressed, soltar sem efeito é
+                // fail-safe.
+                let state: tauri::State<'_, crate::commands::AppState> = app_for_handler.state();
+                let quick_mode = state.config.read().unwrap().interaction.quick_mode;
+                if quick_mode {
+                    let _ = app_for_handler.emit_to("donut", SHORTCUT_RELEASED_EVENT, ());
+                }
             }
         })
         .map_err(|e| {

--- a/src/core/ipc.ts
+++ b/src/core/ipc.ts
@@ -216,7 +216,7 @@ export const CONFIG_CHANGED_EVENT = "config-changed";
 export const SETTINGS_INTENT_EVENT = "settings-intent";
 export const UPDATE_PROGRESS_EVENT = "update-progress";
 /** Issue #71 — emitido pelo backend quando o atalho global é solto e
- *  `interaction.gameslike` está ligado. O frontend do donut consome para
+ *  `interaction.quickMode` está ligado. O frontend do donut consome para
  *  abrir o tab sob o cursor (se houver) e esconder a janela. */
 export const SHORTCUT_RELEASED_EVENT = "shortcut-released";
 

--- a/src/core/ipc.ts
+++ b/src/core/ipc.ts
@@ -89,6 +89,11 @@ export const ipc = {
    *  Mora em `interaction.sliceGapEnabled` (global, não per-perfil). */
   setSliceGapEnabled: (enabled: boolean) =>
     invoke<Config>("set_slice_gap_enabled", { enabled }),
+  /** Issue #71 — toggle do "modo rápido": donut só visível enquanto o
+   *  atalho global está pressionado; soltar abre o tab sob o cursor.
+   *  Mora em `interaction.quickMode` (global, não per-perfil). */
+  setQuickMode: (enabled: boolean) =>
+    invoke<Config>("set_quick_mode", { enabled }),
   /** Issue #52 — alterna onde o donut nasce ao abrir: na posição do mouse
    *  (`cursor`) ou no centro do monitor ativo (`center`). */
   setSpawnPosition: (position: SpawnPosition) =>
@@ -210,6 +215,10 @@ export const dialog = {
 export const CONFIG_CHANGED_EVENT = "config-changed";
 export const SETTINGS_INTENT_EVENT = "settings-intent";
 export const UPDATE_PROGRESS_EVENT = "update-progress";
+/** Issue #71 — emitido pelo backend quando o atalho global é solto e
+ *  `interaction.gameslike` está ligado. O frontend do donut consome para
+ *  abrir o tab sob o cursor (se houver) e esconder a janela. */
+export const SHORTCUT_RELEASED_EVENT = "shortcut-released";
 
 export interface UpdateProgress {
   downloaded: number;

--- a/src/core/types/Interaction.ts
+++ b/src/core/types/Interaction.ts
@@ -15,4 +15,13 @@ searchShortcut: string,
  * original Plano 16). Configs anteriores deserializam como `true`
  * graças ao `#[serde(default = "default_slice_gap_enabled")]`.
  */
-sliceGapEnabled: boolean, };
+sliceGapEnabled: boolean, 
+/**
+ * Issue #71 — "modo rápido". Quando `true`, o donut só fica visível
+ * enquanto o atalho global estiver pressionado: soltar a tecla abre
+ * a aba sob o cursor (se houver) e esconde o donut. Default `false`
+ * preserva o comportamento click-to-open. Configs anteriores
+ * deserializam como `false` graças ao
+ * `#[serde(default)]` (bool default). Wire: `quickMode` (camelCase).
+ */
+quickMode: boolean, };

--- a/src/donut/CenterCircle.tsx
+++ b/src/donut/CenterCircle.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTheme } from "./themeContext";
 
 export interface CenterCircleProps {
@@ -7,6 +7,11 @@ export interface CenterCircleProps {
   r: number;
   onGearClick?: () => void;
   onProfileSwitcherClick?: () => void;
+  /** Issue #71 — emite mudanças do estado de hover das metades pra que o
+   *  `<Donut>` saiba quando o cursor está sobre o gear/profile-switcher.
+   *  Usado pelo modo rápido pra disparar `openSettings` ao soltar o
+   *  atalho global sobre o ícone de engrenagem. */
+  onHoverChange?: (half: "left" | "right" | null) => void;
 }
 
 type Half = "left" | "right" | null;
@@ -27,9 +32,13 @@ export const CenterCircle: React.FC<CenterCircleProps> = ({
   r,
   onGearClick,
   onProfileSwitcherClick,
+  onHoverChange,
 }) => {
   const tokens = useTheme();
   const [hovered, setHovered] = useState<Half>(null);
+  useEffect(() => {
+    onHoverChange?.(hovered);
+  }, [hovered, onHoverChange]);
   const leftHover = hovered === "left" && !!onGearClick;
   const rightHover = hovered === "right" && !!onProfileSwitcherClick;
   return (

--- a/src/donut/Donut.tsx
+++ b/src/donut/Donut.tsx
@@ -27,6 +27,8 @@ import { tabInitial } from "./tabUtils";
 import { ThemeContext } from "./themeContext";
 import { resolvePresetTokens, type ThemeTokens } from "../core/themeTokens";
 import { useRingStack, MAX_RINGS } from "./useRingStack";
+import { useHoverToExpand } from "./useHoverToExpand";
+import { useHoverToCollapse } from "./useHoverToCollapse";
 
 /** Stack de fontes sans-serif do sistema. SVG `<text>` default cai em Times
  *  serif em vários navegadores — feio dentro do donut. Aplicado na raiz
@@ -377,16 +379,37 @@ export const Donut: React.FC<DonutProps> = ({
 
   // Hover-to-expand: passar o cursor sobre um group abre o sub-anel
   // instantaneamente. Comportamento universal — não depende do modo
-  // modo rápido. `expand` é idempotente: re-hover no mesmo group não fecha o
-  // ring, então o cursor pode entrar/sair do slice livremente enquanto o
-  // sub-donut continua aberto. Click no group continua chamando `toggle`,
-  // que vira o gesto de fechar.
-  const expandRing = ringStack.expand;
-  useEffect(() => {
-    if (!hoveredInfo) return;
-    if (!isGroup(hoveredInfo.tab)) return;
-    expandRing(hoveredInfo.tab.id, hoveredInfo.ringDepth);
-  }, [hoveredInfo, expandRing]);
+  // rápido. `useHoverToExpand` guarda a expansão pela string `id`,
+  // evitando re-disparo quando outra atualização (ex.: o próprio `toggle`
+  // de fechamento por click) regenera as refs upstream sem mudar de fato
+  // o group sob o cursor. Click no group continua chamando `toggle`, que
+  // permanece como o gesto de fechar.
+  const hoveredGroup = useMemo(
+    () =>
+      hoveredInfo && isGroup(hoveredInfo.tab)
+        ? { id: hoveredInfo.tab.id, depth: hoveredInfo.ringDepth }
+        : null,
+    [hoveredInfo],
+  );
+  useHoverToExpand(hoveredGroup, ringStack.expand);
+
+  // Hover-to-collapse: complementa o hover-to-expand. Quando o cursor sai
+  // da fatia do group E do anel externo correspondente, o group volta
+  // (sem precisar de click). Pausa enquanto context-menu/search overlay
+  // estão abertos pra não colapsar a estrutura por baixo do user.
+  const hoveredForCollapse = useMemo(() => {
+    if (mode !== "tabs" || hovered === null) return null;
+    const { ring, slice } = decodeHoverIndex(hovered);
+    if (ring < 0 || ring >= currentPerRing.length) return null;
+    const tab = currentPerRing[ring].tabs[slice];
+    return { ring, tabId: tab?.id ?? null };
+  }, [mode, hovered, currentPerRing]);
+  useHoverToCollapse({
+    hovered: hoveredForCollapse,
+    expandedGroupIds: ringStack.expandedGroupIds,
+    trim: ringStack.trimToLength,
+    enabled: !contextMenu && !searchOpen,
+  });
 
   const isTabSlice = (idx: number) => {
     const { ring, slice } = decodeHoverIndex(idx);

--- a/src/donut/Donut.tsx
+++ b/src/donut/Donut.tsx
@@ -13,6 +13,7 @@ import {
   pointToRingIndex,
   pointToSliceIndex,
   ringDims,
+  ringHitBounds,
   slicePaintRange,
   type RingDims,
 } from "./geometry";
@@ -323,7 +324,13 @@ export const Donut: React.FC<DonutProps> = ({
       setHovered(null);
       return;
     }
-    const dims = ringDims(ring, innerRRoot, outerRRoot);
+    // Issue #71 — hit-test usa `ringHitBounds` (sem gap) pra que o
+    // cursor passando pela "região morta" radial entre ring 0 e ring 1
+    // ainda mapeie pra um slice válido do ring externo, em vez de
+    // virar `null` e colapsar o sub-anel. Pintura (mais abaixo)
+    // continua via `ringDims`, então o respiro visual entre anéis
+    // fica intacto.
+    const dims = ringHitBounds(ring, innerRRoot, outerRRoot);
     const current = currentPerRing[ring];
     const sliceCount = current.tabs.length + (current.hasPlus ? 1 : 0);
     if (sliceCount <= 0) {

--- a/src/donut/Donut.tsx
+++ b/src/donut/Donut.tsx
@@ -150,7 +150,18 @@ export interface DonutProps {
   activeProfileId?: string;
   onSelectProfile?: (profileId: string) => void;
   onCreateProfile?: () => void;
+  /** Issue #71 — sobe pra o entry o alvo atualmente sob o cursor. Usado
+   *  pelo modo modo rápido: ao soltar o atalho global, o entry decide ação
+   *  baseado no kind (leaf → openTab, group → só esconde, gear →
+   *  openSettings, null → esconde). */
+  onHoverChange?: (target: DonutHoverTarget) => void;
 }
+
+export type DonutHoverTarget =
+  | { kind: "leaf"; id: string }
+  | { kind: "group"; id: string }
+  | { kind: "gear" }
+  | null;
 
 const PLUS_KEY = "__plus__";
 const DEFAULT_TOKENS: ThemeTokens = resolvePresetTokens("dark");
@@ -183,6 +194,7 @@ export const Donut: React.FC<DonutProps> = ({
   activeProfileId,
   onSelectProfile,
   onCreateProfile,
+  onHoverChange,
 }) => {
   const effectiveTokens = tokens ?? DEFAULT_TOKENS;
   const cx = size / 2;
@@ -328,6 +340,54 @@ export const Donut: React.FC<DonutProps> = ({
   };
   const onMouseLeave = () => setHovered(null);
 
+  // Issue #71 — resolve o tab atualmente sob o cursor (não dispara em
+  // hover do "+" ou fora de slice). Em modo profile-switcher o hover não
+  // representa uma tab abrível, então mantemos `null`.
+  const hoveredInfo = useMemo<{
+    tab: Tab;
+    ringDepth: number;
+  } | null>(() => {
+    if (mode !== "tabs" || hovered === null) return null;
+    const { ring, slice } = decodeHoverIndex(hovered);
+    if (ring < 0 || ring >= currentPerRing.length) return null;
+    const tab = currentPerRing[ring].tabs[slice];
+    if (!tab) return null;
+    return { tab, ringDepth: visibleRings[ring]?.depth ?? ring };
+  }, [hovered, currentPerRing, visibleRings, mode]);
+
+  // Issue #71 — tracking do hover sobre o CenterCircle. Permite que o entry
+  // saiba quando o cursor está sobre o gear (left) — release-over-gear no
+  // modo modo rápido abre Settings.
+  const [centerHover, setCenterHover] = useState<"left" | "right" | null>(null);
+
+  const hoverTarget = useMemo<DonutHoverTarget>(() => {
+    if (mode !== "tabs") return null;
+    if (centerHover === "left") return { kind: "gear" };
+    if (hoveredInfo) {
+      return isGroup(hoveredInfo.tab)
+        ? { kind: "group", id: hoveredInfo.tab.id }
+        : { kind: "leaf", id: hoveredInfo.tab.id };
+    }
+    return null;
+  }, [mode, centerHover, hoveredInfo]);
+
+  useEffect(() => {
+    onHoverChange?.(hoverTarget);
+  }, [hoverTarget, onHoverChange]);
+
+  // Hover-to-expand: passar o cursor sobre um group abre o sub-anel
+  // instantaneamente. Comportamento universal — não depende do modo
+  // modo rápido. `expand` é idempotente: re-hover no mesmo group não fecha o
+  // ring, então o cursor pode entrar/sair do slice livremente enquanto o
+  // sub-donut continua aberto. Click no group continua chamando `toggle`,
+  // que vira o gesto de fechar.
+  const expandRing = ringStack.expand;
+  useEffect(() => {
+    if (!hoveredInfo) return;
+    if (!isGroup(hoveredInfo.tab)) return;
+    expandRing(hoveredInfo.tab.id, hoveredInfo.ringDepth);
+  }, [hoveredInfo, expandRing]);
+
   const isTabSlice = (idx: number) => {
     const { ring, slice } = decodeHoverIndex(idx);
     if (ring < 0 || ring >= currentPerRing.length) return false;
@@ -448,6 +508,7 @@ export const Donut: React.FC<DonutProps> = ({
             r={innerRRoot * 0.85}
             onGearClick={onOpenSettings}
             onProfileSwitcherClick={() => setMode("tabs")}
+            onHoverChange={setCenterHover}
           />
         </svg>
       </ThemeContext.Provider>
@@ -635,6 +696,7 @@ export const Donut: React.FC<DonutProps> = ({
             onProfileSwitcherClick={
               switcherEnabled ? () => setMode("profiles") : undefined
             }
+            onHoverChange={setCenterHover}
           />
           {outermostPagesCount > 1 && (
             <PaginationDots

--- a/src/donut/__tests__/geometry.test.ts
+++ b/src/donut/__tests__/geometry.test.ts
@@ -4,6 +4,7 @@ import {
   pointToSliceIndex,
   arcPath,
   ringDims,
+  ringHitBounds,
   pointToRingIndex,
   slicePaintRange,
 } from "../geometry";
@@ -102,6 +103,37 @@ describe("ringDims", () => {
   });
 });
 
+describe("ringHitBounds (Issue #71 — gapless hit-test)", () => {
+  it("ring 0 é idêntico a ringDims (sem absorver — não há gap antes)", () => {
+    const d = ringHitBounds(0, 80, 160);
+    expect(d.innerR).toBe(80);
+    expect(d.outerR).toBe(160);
+  });
+
+  it("ring 1 absorve o gap radial que o precede (inner = outer paint do ring 0)", () => {
+    // ringDims(1) = {164, 224}; ringHitBounds(1) = {160, 224}.
+    // Os 4px do gap (160..164) ficam englobados no hit zone do ring 1.
+    const d = ringHitBounds(1, 80, 160);
+    expect(d.innerR).toBe(160);
+    expect(d.outerR).toBe(224);
+  });
+
+  it("ring 2 absorve seu gap antecedente (inner = outer paint do ring 1)", () => {
+    // ringDims(2) = {228, 288}; ringHitBounds(2) = {224, 288}.
+    const d = ringHitBounds(2, 80, 160);
+    expect(d.innerR).toBe(224);
+    expect(d.outerR).toBe(288);
+  });
+
+  it("hit bounds são contíguos (ring N.outerR == ring N+1.innerR) — sem buracos", () => {
+    const r0 = ringHitBounds(0, 80, 160);
+    const r1 = ringHitBounds(1, 80, 160);
+    const r2 = ringHitBounds(2, 80, 160);
+    expect(r0.outerR).toBe(r1.innerR);
+    expect(r1.outerR).toBe(r2.innerR);
+  });
+});
+
 describe("pointToRingIndex", () => {
   it("retorna null pra ponto dentro do círculo central", () => {
     expect(pointToRingIndex({ x: 0, y: 0 }, 3, 80, 160)).toBeNull();
@@ -113,24 +145,33 @@ describe("pointToRingIndex", () => {
     expect(pointToRingIndex({ x: 159, y: 0 }, 3, 80, 160)).toBe(0);
   });
 
-  it("retorna null pra ponto no gap entre rings", () => {
-    // Gap entre ring 0 (160) e ring 1 (164) = 161..163.
-    expect(pointToRingIndex({ x: 162, y: 0 }, 3, 80, 160)).toBeNull();
+  it("Issue #71 — gap entre ring 0 e ring 1 absorve no ring 1 (sem mais buraco que disparava collapse)", () => {
+    // Pintura: ring 0 (até 160), gap (161..163), ring 1 (164..224).
+    // Hit-test: ring 1 começa em 160, absorvendo o gap.
+    expect(pointToRingIndex({ x: 162, y: 0 }, 3, 80, 160)).toBe(1);
   });
 
-  it("identifica ring 1 (banda externa)", () => {
+  it("identifica ring 1 (banda externa, incluindo o gap radial absorvido)", () => {
     expect(pointToRingIndex({ x: 170, y: 0 }, 3, 80, 160)).toBe(1);
     expect(pointToRingIndex({ x: 220, y: 0 }, 3, 80, 160)).toBe(1);
   });
 
-  it("retorna null pra ponto no gap entre ring 1 e ring 2", () => {
-    // ring 1 outer = 224; ring 2 inner = 228. Gap = 225..227.
-    expect(pointToRingIndex({ x: 226, y: 0 }, 3, 80, 160)).toBeNull();
+  it("Issue #71 — gap entre ring 1 e ring 2 absorve no ring 2", () => {
+    // Pintura: ring 1 outer paint = 224; ring 2 inner paint = 228.
+    // Gap pintado em 225..227; hit-test mapeia tudo isso pra ring 2.
+    expect(pointToRingIndex({ x: 226, y: 0 }, 3, 80, 160)).toBe(2);
   });
 
   it("identifica ring 2 (outermost)", () => {
     expect(pointToRingIndex({ x: 230, y: 0 }, 3, 80, 160)).toBe(2);
     expect(pointToRingIndex({ x: 285, y: 0 }, 3, 80, 160)).toBe(2);
+  });
+
+  it("Issue #71 — gap radial sem ring externo disponível continua null (não há onde absorver)", () => {
+    // ringCount=1: só ring 0 existe. Ponto em (162, 0) está fora da
+    // banda do ring 0 (que termina em 160) e não tem ring 1 pra
+    // absorver. Retorna null como esperado.
+    expect(pointToRingIndex({ x: 162, y: 0 }, 1, 80, 160)).toBeNull();
   });
 
   it("retorna null pra ponto fora do ring outermost", () => {

--- a/src/donut/__tests__/quickRelease.test.ts
+++ b/src/donut/__tests__/quickRelease.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { decideQuickRelease } from "../quickRelease";
+import type { Config } from "../../core/types/Config";
+
+function makeConfig(quickMode: boolean): Config {
+  // Apenas os campos lidos por `decideQuickRelease` precisam ser
+  // realistas. Os demais são preenchidos com valores neutros pra satisfazer
+  // o tipo gerado pelo ts-rs sem nos amarrar ao schema completo nesta
+  // suíte de unit tests.
+  return {
+    version: 2,
+    activeProfileId: "p",
+    profiles: [],
+    appearance: { language: "auto" },
+    interaction: {
+      spawnPosition: "cursor",
+      selectionMode: "clickOrRelease",
+      hoverHoldMs: 1200,
+      searchShortcut: "CommandOrControl+F",
+      sliceGapEnabled: true,
+      quickMode,
+    },
+    pagination: { itemsPerPage: 6, wheelDirection: "standard" },
+    system: {
+      autostart: false,
+      autoCheckUpdates: true,
+      scriptHistoryEnabled: true,
+    },
+  } as unknown as Config;
+}
+
+describe("decideQuickRelease", () => {
+  it("returns noop when config is null (boot race: release before hydration)", () => {
+    expect(decideQuickRelease(null, { kind: "leaf", id: "t1" })).toEqual({
+      type: "noop",
+    });
+  });
+
+  it("returns noop when quickMode is disabled (release does nothing in click-to-open mode)", () => {
+    expect(
+      decideQuickRelease(makeConfig(false), { kind: "leaf", id: "t1" }),
+    ).toEqual({ type: "noop" });
+  });
+
+  it("opens the leaf tab under the cursor when quickMode is on", () => {
+    expect(
+      decideQuickRelease(makeConfig(true), { kind: "leaf", id: "t1" }),
+    ).toEqual({ type: "openTab", tabId: "t1" });
+  });
+
+  it("opens settings when cursor is on the gear", () => {
+    expect(decideQuickRelease(makeConfig(true), { kind: "gear" })).toEqual({
+      type: "openSettings",
+    });
+  });
+
+  it("hides the donut when cursor is on a group (no leaf to open)", () => {
+    expect(
+      decideQuickRelease(makeConfig(true), { kind: "group", id: "g1" }),
+    ).toEqual({ type: "hide" });
+  });
+
+  it("hides the donut when cursor is on no target (outside slices)", () => {
+    expect(decideQuickRelease(makeConfig(true), null)).toEqual({
+      type: "hide",
+    });
+  });
+});

--- a/src/donut/__tests__/useHoverToCollapse.test.tsx
+++ b/src/donut/__tests__/useHoverToCollapse.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, type Mock } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+  computeTrimLength,
+  useHoverToCollapse,
+  type HoveredForCollapse,
+} from "../useHoverToCollapse";
+
+/** Invoca o último updater capturado pelo mock de `trim`, passando
+ *  `current` como o estado pós-batch hipotético, e devolve o `len`
+ *  calculado. Necessário porque o hook agora chama `trim((c) => len)`
+ *  em vez de `trim(len)` — o cálculo é lazy. */
+function lastCalledLen(trim: Mock, current: string[]): number {
+  const calls = trim.mock.calls;
+  if (calls.length === 0) throw new Error("trim not called");
+  const lastCall = calls[calls.length - 1];
+  return (lastCall[0] as (c: string[]) => number)(current);
+}
+
+describe("computeTrimLength (pure)", () => {
+  it("returns 0 when cursor is outside the donut", () => {
+    expect(computeTrimLength(null, ["g"])).toBe(0);
+  });
+
+  it("returns 0 when no groups are expanded and cursor is on root", () => {
+    expect(computeTrimLength({ ring: 0, tabId: "x" }, [])).toBe(0);
+  });
+
+  it("keeps the group at depth 0 when cursor is on its own slice (ring 0)", () => {
+    expect(computeTrimLength({ ring: 0, tabId: "g" }, ["g"])).toBe(1);
+  });
+
+  it("collapses the group at depth 0 when cursor is on a sibling at ring 0", () => {
+    expect(computeTrimLength({ ring: 0, tabId: "sibling" }, ["g"])).toBe(0);
+  });
+
+  it("keeps the group at depth 0 when cursor is in its children ring (ring 1)", () => {
+    // Cursor em ring 1 (children ring) — ring > depth → group em depth 0 stays.
+    expect(computeTrimLength({ ring: 1, tabId: "child" }, ["g"])).toBe(1);
+  });
+
+  it("keeps the group at depth 0 when cursor is on the '+' slice of the children ring (tabId null)", () => {
+    expect(computeTrimLength({ ring: 1, tabId: null }, ["g"])).toBe(1);
+  });
+
+  it("collapses everything when cursor is on a root sibling and nested groups are expanded", () => {
+    expect(
+      computeTrimLength({ ring: 0, tabId: "sibling" }, ["g1", "g2"]),
+    ).toBe(0);
+  });
+
+  it("keeps both nested groups when cursor is on the deepest ring", () => {
+    expect(computeTrimLength({ ring: 2, tabId: "leaf" }, ["g1", "g2"])).toBe(2);
+  });
+
+  it("collapses only the deepest nested group when cursor is on a sibling of it (ring 1)", () => {
+    expect(
+      computeTrimLength({ ring: 1, tabId: "sibling-of-g2" }, ["g1", "g2"]),
+    ).toBe(1);
+  });
+
+  it("keeps both nested groups when cursor is on the inner group's own slice at ring 1", () => {
+    expect(computeTrimLength({ ring: 1, tabId: "g2" }, ["g1", "g2"])).toBe(2);
+  });
+});
+
+type CollapseProps = {
+  hovered: HoveredForCollapse | null;
+  expandedGroupIds: string[];
+};
+
+type CollapsePropsWithEnabled = CollapseProps & { enabled: boolean };
+
+describe("useHoverToCollapse", () => {
+  it("does NOT call trim on the initial mount with hovered=null (no cursor yet — regression: was collapsing groups opened by click without prior mouseMove)", () => {
+    const trim = vi.fn();
+    renderHook(
+      (props: CollapseProps) =>
+        useHoverToCollapse({
+          hovered: props.hovered,
+          expandedGroupIds: props.expandedGroupIds,
+          trim,
+        }),
+      {
+        initialProps: {
+          hovered: null,
+          expandedGroupIds: ["g"],
+        } as CollapseProps,
+      },
+    );
+    expect(trim).not.toHaveBeenCalled();
+  });
+
+  it("calls trim when hover transitions and re-computes length on subsequent moves", () => {
+    const trim = vi.fn();
+    const { rerender } = renderHook(
+      (props: CollapseProps) =>
+        useHoverToCollapse({
+          hovered: props.hovered,
+          expandedGroupIds: props.expandedGroupIds,
+          trim,
+        }),
+      {
+        initialProps: {
+          hovered: null,
+          expandedGroupIds: [],
+        } as CollapseProps,
+      },
+    );
+    expect(trim).not.toHaveBeenCalled();
+
+    rerender({ hovered: { ring: 0, tabId: "g" }, expandedGroupIds: ["g"] });
+    // Computa contra o `current` pós-expand hipotético `["g"]` →
+    // group em depth 0 fica (cursor está sobre ele) → len 1.
+    expect(lastCalledLen(trim, ["g"])).toBe(1);
+
+    rerender({
+      hovered: { ring: 0, tabId: "sibling" },
+      expandedGroupIds: ["g"],
+    });
+    // Cursor saiu pra sibling no mesmo ring → colapsa tudo daquele depth.
+    expect(lastCalledLen(trim, ["g"])).toBe(0);
+
+    rerender({ hovered: null, expandedGroupIds: [] });
+    // Cursor fora do donut → tudo colapsa, independente do `current`.
+    expect(lastCalledLen(trim, ["g"])).toBe(0);
+  });
+
+  it("does not call trim when the hover snapshot is value-equal across re-renders (different object ref, same ring+tabId)", () => {
+    const trim = vi.fn();
+    const { rerender } = renderHook(
+      (props: CollapseProps) =>
+        useHoverToCollapse({
+          hovered: props.hovered,
+          expandedGroupIds: props.expandedGroupIds,
+          trim,
+        }),
+      {
+        initialProps: {
+          hovered: { ring: 0, tabId: "g" } as HoveredForCollapse | null,
+          expandedGroupIds: ["g"],
+        },
+      },
+    );
+    expect(trim).toHaveBeenCalledTimes(1);
+    // Re-render com mesmo ring+tabId mas objeto novo (simula re-memo upstream).
+    rerender({ hovered: { ring: 0, tabId: "g" }, expandedGroupIds: ["g"] });
+    expect(trim).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call trim while enabled = false (context menu / search overlay paused)", () => {
+    const trim = vi.fn();
+    const { rerender } = renderHook(
+      (props: CollapsePropsWithEnabled) =>
+        useHoverToCollapse({
+          hovered: props.hovered,
+          expandedGroupIds: props.expandedGroupIds,
+          trim,
+          enabled: props.enabled,
+        }),
+      {
+        initialProps: {
+          hovered: { ring: 0, tabId: "g" },
+          expandedGroupIds: ["g"],
+          enabled: false,
+        } as CollapsePropsWithEnabled,
+      },
+    );
+    expect(trim).not.toHaveBeenCalled();
+    // Hover muda mas continua pausado — nada é chamado.
+    rerender({
+      hovered: { ring: 0, tabId: "sibling" },
+      expandedGroupIds: ["g"],
+      enabled: false,
+    });
+    expect(trim).not.toHaveBeenCalled();
+    // Volta a habilitar — dispara o cálculo atual.
+    rerender({
+      hovered: { ring: 0, tabId: "sibling" },
+      expandedGroupIds: ["g"],
+      enabled: true,
+    });
+    expect(trim).toHaveBeenCalledTimes(1);
+    expect(lastCalledLen(trim, ["g"])).toBe(0);
+  });
+
+  it("trim closure reads the `current` passed by the updater (not the prop `expandedGroupIds` from the stale render)", () => {
+    // Garantia explícita do contrato anti-race: se o cálculo dependesse
+    // do prop `expandedGroupIds` (snapshot pré-expand), o expand
+    // concorrente seria anulado. O hook deve passar `current` pro
+    // computeTrimLength — exatamente o que esse teste checa.
+    const trim = vi.fn();
+    renderHook(() =>
+      useHoverToCollapse({
+        hovered: { ring: 0, tabId: "g" },
+        expandedGroupIds: [], // prop stale (simula pré-expand)
+        trim,
+      }),
+    );
+    // Invoca o updater com o estado pós-expand real (`["g"]`):
+    expect(lastCalledLen(trim, ["g"])).toBe(1);
+    // E com o estado vazio (sanity):
+    expect(lastCalledLen(trim, [])).toBe(0);
+  });
+});

--- a/src/donut/__tests__/useHoverToExpand.test.tsx
+++ b/src/donut/__tests__/useHoverToExpand.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useHoverToExpand, type HoveredGroup } from "../useHoverToExpand";
+
+describe("useHoverToExpand", () => {
+  it("fires expand the first time a group is hovered", () => {
+    const expand = vi.fn();
+    renderHook(({ g }: { g: HoveredGroup | null }) => useHoverToExpand(g, expand), {
+      initialProps: { g: { id: "g1", depth: 0 } },
+    });
+    expect(expand).toHaveBeenCalledTimes(1);
+    expect(expand).toHaveBeenCalledWith("g1", 0);
+  });
+
+  it("does not fire when nothing is hovered", () => {
+    const expand = vi.fn();
+    renderHook(({ g }: { g: HoveredGroup | null }) => useHoverToExpand(g, expand), {
+      initialProps: { g: null },
+    });
+    expect(expand).not.toHaveBeenCalled();
+  });
+
+  it("does NOT re-fire when the hoveredGroup reference changes but the id stays the same (regression: click-to-close was reopening)", () => {
+    const expand = vi.fn();
+    const { rerender } = renderHook(
+      ({ g }: { g: HoveredGroup | null }) => useHoverToExpand(g, expand),
+      { initialProps: { g: { id: "g1", depth: 0 } } },
+    );
+    expect(expand).toHaveBeenCalledTimes(1);
+    // Simulates the bug condition: upstream useMemo creates a new object
+    // with the same id (e.g., after `toggle` collapses the ring and
+    // `currentPerRing` is recomputed). Without the id guard, this would
+    // re-fire `expand` and reopen the ring.
+    rerender({ g: { id: "g1", depth: 0 } });
+    expect(expand).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires expand again when transitioning to a different group", () => {
+    const expand = vi.fn();
+    const { rerender } = renderHook(
+      ({ g }: { g: HoveredGroup | null }) => useHoverToExpand(g, expand),
+      { initialProps: { g: { id: "g1", depth: 0 } } },
+    );
+    rerender({ g: { id: "g2", depth: 0 } });
+    expect(expand).toHaveBeenCalledTimes(2);
+    expect(expand).toHaveBeenLastCalledWith("g2", 0);
+  });
+
+  it("after cursor leaves and re-enters the same group, expand fires again", () => {
+    const expand = vi.fn();
+    const { rerender } = renderHook(
+      ({ g }: { g: HoveredGroup | null }) => useHoverToExpand(g, expand),
+      { initialProps: { g: { id: "g1", depth: 0 } as HoveredGroup | null } },
+    );
+    rerender({ g: null });
+    rerender({ g: { id: "g1", depth: 0 } });
+    expect(expand).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards the ring depth to expand", () => {
+    const expand = vi.fn();
+    renderHook(({ g }: { g: HoveredGroup | null }) => useHoverToExpand(g, expand), {
+      initialProps: { g: { id: "deep", depth: 1 } },
+    });
+    expect(expand).toHaveBeenCalledWith("deep", 1);
+  });
+});

--- a/src/donut/__tests__/useRingStack.test.tsx
+++ b/src/donut/__tests__/useRingStack.test.tsx
@@ -156,4 +156,66 @@ describe("useRingStack", () => {
     expect(result.current.expandedGroupIds).toEqual(["g1"]);
     expect(result.current.rings).toHaveLength(2);
   });
+
+  it("trimToLength shortens expandedGroupIds to the length returned by computeLen", () => {
+    const tabs = [group("g", [leaf("g1")])];
+    const { result } = renderHook(() => useRingStack(tabs));
+    act(() => result.current.expand("g", 0));
+    expect(result.current.expandedGroupIds).toEqual(["g"]);
+    act(() => result.current.trimToLength(() => 0));
+    expect(result.current.expandedGroupIds).toEqual([]);
+    expect(result.current.rings).toHaveLength(1);
+  });
+
+  it("trimToLength is idempotent (no-op when computeLen returns >= current length)", () => {
+    const tabs = [group("g", [leaf("g1")])];
+    const { result } = renderHook(() => useRingStack(tabs));
+    act(() => result.current.expand("g", 0));
+    const ref = result.current.expandedGroupIds;
+    act(() => result.current.trimToLength(() => 5));
+    // Mesma referência preservada — nenhum re-render por causa do trim.
+    expect(result.current.expandedGroupIds).toBe(ref);
+    act(() => result.current.trimToLength(() => 1));
+    expect(result.current.expandedGroupIds).toBe(ref);
+  });
+
+  it("trimToLength clamps negative computeLen output to 0", () => {
+    const tabs = [group("g", [leaf("g1")])];
+    const { result } = renderHook(() => useRingStack(tabs));
+    act(() => result.current.expand("g", 0));
+    act(() => result.current.trimToLength(() => -3));
+    expect(result.current.expandedGroupIds).toEqual([]);
+  });
+
+  it("trimToLength's computeLen receives the current (post-update) expandedGroupIds", () => {
+    const tabs = [group("g", [leaf("g1")])];
+    const { result } = renderHook(() => useRingStack(tabs));
+    act(() => result.current.expand("g", 0));
+    let received: string[] | null = null;
+    act(() =>
+      result.current.trimToLength((c) => {
+        received = c.slice();
+        return c.length;
+      }),
+    );
+    expect(received).toEqual(["g"]);
+  });
+
+  it("trimToLength does not undo a concurrent expand (race regression: hover-expand + hover-collapse in same commit must not cancel out)", () => {
+    const tabs = [group("g", [leaf("g1")])];
+    const { result } = renderHook(() => useRingStack(tabs));
+    // Mesma fase de effects: expand e trim disparam juntos. Trim usa
+    // updater funcional que enxerga o expand já aplicado, então
+    // mantém o que expand colocou (cursor em (0, g) → len = 1).
+    act(() => {
+      result.current.expand("g", 0);
+      result.current.trimToLength((current) => {
+        // Simula computeTrimLength({ring:0,tabId:"g"}, current):
+        // ring(0) < current.length(1) && tabId === current[0] → len 1.
+        if (current.length > 0 && current[0] === "g") return 1;
+        return 0;
+      });
+    });
+    expect(result.current.expandedGroupIds).toEqual(["g"]);
+  });
 });

--- a/src/donut/__tests__/useRingStack.test.tsx
+++ b/src/donut/__tests__/useRingStack.test.tsx
@@ -114,4 +114,46 @@ describe("useRingStack", () => {
     expect(result.current.expandedGroupIds).toEqual([]);
     expect(result.current.rings).toHaveLength(1);
   });
+
+  it("expand at depth 0 opens ring 1 with the group's children", () => {
+    const tabs = [group("g", [leaf("g1"), leaf("g2")])];
+    const { result } = renderHook(() => useRingStack(tabs));
+    act(() => result.current.expand("g", 0));
+    expect(result.current.expandedGroupIds).toEqual(["g"]);
+    expect(result.current.rings).toHaveLength(2);
+    expect(result.current.rings[1].tabs.map((t) => t.id)).toEqual(["g1", "g2"]);
+  });
+
+  it("expand is idempotent: re-expanding the same group keeps ring open", () => {
+    const tabs = [group("g", [leaf("g1")])];
+    const { result } = renderHook(() => useRingStack(tabs));
+    act(() => result.current.expand("g", 0));
+    expect(result.current.rings).toHaveLength(2);
+    // Diferente de toggle: chamar de novo NÃO fecha.
+    act(() => result.current.expand("g", 0));
+    expect(result.current.expandedGroupIds).toEqual(["g"]);
+    expect(result.current.rings).toHaveLength(2);
+  });
+
+  it("expand replaces a different group at the same depth", () => {
+    const tabs = [
+      group("a", [leaf("a1")]),
+      group("b", [leaf("b1")]),
+    ];
+    const { result } = renderHook(() => useRingStack(tabs));
+    act(() => result.current.expand("a", 0));
+    expect(result.current.rings[1].tabs[0].id).toBe("a1");
+    act(() => result.current.expand("b", 0));
+    expect(result.current.expandedGroupIds).toEqual(["b"]);
+    expect(result.current.rings[1].tabs[0].id).toBe("b1");
+  });
+
+  it("expand at outermost depth (MAX-1) is no-op", () => {
+    const tabs = [group("g1", [group("g2", [leaf("l")])])];
+    const { result } = renderHook(() => useRingStack(tabs));
+    act(() => result.current.expand("g1", 0));
+    act(() => result.current.expand("g2", 1));
+    expect(result.current.expandedGroupIds).toEqual(["g1"]);
+    expect(result.current.rings).toHaveLength(2);
+  });
 });

--- a/src/donut/geometry.ts
+++ b/src/donut/geometry.ts
@@ -87,13 +87,19 @@ export const RING_GAP = 4;
 export const OUTER_SLICE_ANGULAR_GAP_RAD = 0.04;
 
 /**
- * Plano 23 — calcula os raios de cada anel concêntrico (`ring 0` =
- * innermost = root; `ring N-1` = outermost). Ring 0 usa a banda derivada
- * do tema (`innerRRoot..outerRRoot`); rings 1+ usam banda menor
- * (`OUTER_RING_BAND_WIDTH`) com `RING_GAP` separando vizinhos.
+ * Plano 23 — calcula os raios de cada anel concêntrico para **pintura**
+ * (`ring 0` = innermost = root; `ring N-1` = outermost). Ring 0 usa a
+ * banda derivada do tema (`innerRRoot..outerRRoot`); rings 1+ usam
+ * banda menor (`OUTER_RING_BAND_WIDTH`) com `RING_GAP` separando
+ * vizinhos.
  *
- * Pure pra teste; reusado pelo `<Donut>` e pelo highlight global pra mapear
- * `radius → ringIndex`.
+ * **Não usar em hit-test** — o gap entre anéis aparece como região
+ * vazia aqui, e cursor passando por ele faria `pointToRingIndex` virar
+ * `null`, derrubando o `hovered` e colapsando rings abertos. Para
+ * hit-test use `ringHitBounds`, que absorve o gap no ring externo.
+ *
+ * Pure pra teste; reusado pelo `<Donut>` na renderização SVG e no
+ * posicionamento do `HoverHoldOverlay`.
  */
 export function ringDims(
   ringIndex: number,
@@ -109,11 +115,44 @@ export function ringDims(
 }
 
 /**
- * Plano 23 — descobre qual anel concêntrico contém o ponto, usando a
- * distância radial. Pure pra teste. Retorna `null` se o ponto está
- * dentro do círculo central (raio < `innerRRoot`), na região de gap
- * entre anéis, ou fora do anel mais externo. `ringCount` define quantos
- * anéis estão renderizados.
+ * Issue #71 — versão sem-gap dos raios concêntricos para uso em
+ * hit-test (`pointToRingIndex` + `pointToSliceIndex` no `<Donut>`).
+ * Cada ring externo absorve o `RING_GAP` que o precede, eliminando a
+ * "região morta" radial onde o cursor virava `null` e disparava
+ * collapse indevido enquanto o usuário transitava do slice do group
+ * para o anel externo.
+ *
+ * Pintura visual (`ringDims`) preserva o gap; só a detecção de
+ * cursor enxerga os anéis contíguos.
+ */
+export function ringHitBounds(
+  ringIndex: number,
+  innerRRoot: number,
+  outerRRoot: number,
+): RingDims {
+  if (ringIndex <= 0) {
+    return { innerR: innerRRoot, outerR: outerRRoot };
+  }
+  // Ring i (>= 1) cobre desde o outer paint do ring anterior até o
+  // outer paint deste ring. O gap radial antes deste ring fica
+  // englobado neste hit zone.
+  const innerR =
+    ringIndex === 1
+      ? outerRRoot
+      : outerRRoot + (ringIndex - 1) * (OUTER_RING_BAND_WIDTH + RING_GAP);
+  const outerR =
+    outerRRoot + ringIndex * (OUTER_RING_BAND_WIDTH + RING_GAP);
+  return { innerR, outerR };
+}
+
+/**
+ * Plano 23 / Issue #71 — descobre qual anel concêntrico contém o ponto,
+ * usando a distância radial. Pure pra teste. Retorna `null` se o ponto
+ * está dentro do círculo central (raio < `innerRRoot`) ou fora do anel
+ * mais externo. **Não retorna `null` para o gap entre anéis** — usa
+ * `ringHitBounds` que absorve o gap no ring externo, evitando que o
+ * cursor "caia no buraco" entre anéis e dispare collapse do sub-anel
+ * que o usuário está prestes a alcançar.
  */
 export function pointToRingIndex(
   p: Point,
@@ -125,7 +164,7 @@ export function pointToRingIndex(
   const r = Math.hypot(p.x, p.y);
   if (r < innerRRoot) return null;
   for (let i = 0; i < ringCount; i++) {
-    const dims = ringDims(i, innerRRoot, outerRRoot);
+    const dims = ringHitBounds(i, innerRRoot, outerRRoot);
     if (r >= dims.innerR && r <= dims.outerR) return i;
   }
   return null;

--- a/src/donut/quickRelease.ts
+++ b/src/donut/quickRelease.ts
@@ -1,0 +1,22 @@
+import type { Config } from "../core/types/Config";
+import type { DonutHoverTarget } from "./Donut";
+
+export type QuickReleaseAction =
+  | { type: "openTab"; tabId: string }
+  | { type: "openSettings" }
+  | { type: "hide" }
+  | { type: "noop" };
+
+/** Issue #71 — decide o que fazer ao soltar o atalho global com modo
+ *  rápido ligado. Retorna `noop` quando o modo está desligado ou a config
+ *  ainda não chegou: o release não dispara nada e o donut fica no fluxo
+ *  click-to-open clássico. */
+export function decideQuickRelease(
+  cfg: Config | null,
+  target: DonutHoverTarget,
+): QuickReleaseAction {
+  if (!cfg?.interaction.quickMode) return { type: "noop" };
+  if (target?.kind === "leaf") return { type: "openTab", tabId: target.id };
+  if (target?.kind === "gear") return { type: "openSettings" };
+  return { type: "hide" };
+}

--- a/src/donut/useHoverToCollapse.ts
+++ b/src/donut/useHoverToCollapse.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from "react";
+
+/** Snapshot do que está sob o cursor relevante para o trim. `ring` é o
+ *  índice do anel concêntrico (0 = root, 1 = primeiro sub-anel, etc.).
+ *  `tabId` é o id da fatia hovered ou `null` se o cursor está sobre o
+ *  "+" / fora de qualquer fatia ainda dentro do ring. */
+export interface HoveredForCollapse {
+  ring: number;
+  tabId: string | null;
+}
+
+/** Issue #71 — pure: dado o cursor atual, calcula o comprimento que
+ *  `expandedGroupIds` deveria ter pra refletir "groups cuja área (própria
+ *  fatia + anel externo de filhos) ainda contém o cursor".
+ *
+ *  Regra: um group expandido a depth `D` permanece aberto se o cursor
+ *  está em (ring D, fatia = id desse group) OU em qualquer ring `> D`.
+ *  Cursor fora do donut (null) → tudo colapsa.
+ */
+export function computeTrimLength(
+  hovered: HoveredForCollapse | null,
+  expandedGroupIds: string[],
+): number {
+  if (hovered === null) return 0;
+  const { ring, tabId } = hovered;
+  // Cursor em ring R > D ⇒ group em depth D fica aberto. Logo, depths
+  // 0..R-1 sempre sobrevivem.
+  let len = ring;
+  // Para depth = ring, sobrevive só se o cursor está na própria fatia
+  // do group expandido nesse depth.
+  if (ring < expandedGroupIds.length && tabId !== null) {
+    if (tabId === expandedGroupIds[ring]) {
+      len = ring + 1;
+    }
+  }
+  return len;
+}
+
+function sameHover(
+  a: HoveredForCollapse | null,
+  b: HoveredForCollapse | null,
+): boolean {
+  if (a === null && b === null) return true;
+  if (a === null || b === null) return false;
+  return a.ring === b.ring && a.tabId === b.tabId;
+}
+
+/** Hook que dispara `trim` quando o cursor **realmente muda** para fora
+ *  da "zona viva" de algum group expandido. A guarda por transição evita
+ *  colapsar no mount inicial (`hovered = null`, sem cursor no donut) e
+ *  imediatamente após um click-to-expand em ambientes (testes) onde o
+ *  hover não é simulado — em uso real, click no slice implica mouseMove
+ *  prévio, mas a guarda mantém a lógica robusta. `enabled = false` pausa
+ *  a captura (ex.: context-menu / overlay de busca abertos não devem
+ *  colapsar rings por baixo do user).
+ *
+ *  `trim` recebe uma **closure** `(current) => len`, não um número direto.
+ *  Isso é proposital: hover-to-expand e hover-to-collapse podem disparar
+ *  no mesmo commit cycle (cursor entra num group), e o cálculo precisa
+ *  rodar contra o `current` pós-expand (não contra `expandedGroupIds`
+ *  capturado do render stale) para não anular o expand recém-aplicado.
+ *  `expandedGroupIds` continua nas deps como trigger de re-evaluação
+ *  para mudanças externas (ex.: `toggle` por click). */
+export function useHoverToCollapse(args: {
+  hovered: HoveredForCollapse | null;
+  expandedGroupIds: string[];
+  trim: (computeLen: (current: string[]) => number) => void;
+  enabled?: boolean;
+}): void {
+  const { hovered, expandedGroupIds, trim, enabled = true } = args;
+  const lastHoveredRef = useRef<HoveredForCollapse | null>(null);
+  useEffect(() => {
+    if (!enabled) return;
+    if (sameHover(lastHoveredRef.current, hovered)) return;
+    lastHoveredRef.current = hovered;
+    trim((current) => computeTrimLength(hovered, current));
+  }, [hovered, expandedGroupIds, trim, enabled]);
+}

--- a/src/donut/useHoverToExpand.ts
+++ b/src/donut/useHoverToExpand.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+
+/** Identidade do group atualmente sob o cursor (ou `null` se não há
+ *  group hovered). Passar a "shape" + a função de expansão para o hook. */
+export interface HoveredGroup {
+  id: string;
+  depth: number;
+}
+
+/** Issue #71 — dispara `expand(id, depth)` apenas quando o grupo sob o
+ *  cursor muda de identidade. Sem essa guarda, qualquer re-render que
+ *  altere a referência do objeto `hoveredGroup` (ex.: click em `toggle`
+ *  que reescreve `expandedGroupIds` → `currentPerRing` ganha nova ref →
+ *  o `useMemo` upstream produz um novo objeto com o mesmo id) re-dispara
+ *  `expand` e desfaz o `toggle` de fechamento. Comparar pela string `id`
+ *  isola "mesmo group, ref nova" do caso real "cursor entrou em outro
+ *  group / saiu e voltou".
+ *
+ *  Pós-fechamento: o user precisa sair do slice e voltar para re-expandir
+ *  via hover (o ref é zerado quando `hoveredGroup` vira `null`).
+ */
+export function useHoverToExpand(
+  hoveredGroup: HoveredGroup | null,
+  expand: (groupId: string, depth: number) => void,
+): void {
+  const lastIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    const currentId = hoveredGroup?.id ?? null;
+    if (currentId === lastIdRef.current) return;
+    lastIdRef.current = currentId;
+    if (hoveredGroup) {
+      expand(hoveredGroup.id, hoveredGroup.depth);
+    }
+  }, [hoveredGroup, expand]);
+}

--- a/src/donut/useRingStack.ts
+++ b/src/donut/useRingStack.ts
@@ -23,6 +23,11 @@ export interface UseRingStack {
    *  expandido, colapsa-o e tudo fora dele. Senão, abre o anel
    *  no nível `depth + 1` substituindo qualquer anel mais externo. */
   toggle: (groupId: string, depth: number) => void;
+  /** Issue #71 — abre o grupo no nível `depth + 1` sem colapsar caso já
+   *  esteja aberto (idempotente). Usado pela expansão por hover: passar o
+   *  cursor de novo sobre o mesmo group não fecha o ring. Se outro group
+   *  estiver expandido nesse depth, substitui. */
+  expand: (groupId: string, depth: number) => void;
   /** Colapsa todos os anéis externos. Equivale a expandedGroupIds = []. */
   collapseAll: () => void;
 }
@@ -106,6 +111,15 @@ export function useRingStack(rootTabs: Tab[]): UseRingStack {
     [],
   );
 
+  const expand = useCallback((groupId: string, depth: number) => {
+    setExpandedGroupIds((current) => {
+      if (depth >= MAX_RINGS - 1) return current;
+      const targetIndex = depth;
+      if (current[targetIndex] === groupId) return current;
+      return [...current.slice(0, targetIndex), groupId];
+    });
+  }, []);
+
   const collapseAll = useCallback(() => {
     setExpandedGroupIds((c) => (c.length === 0 ? c : []));
   }, []);
@@ -114,6 +128,7 @@ export function useRingStack(rootTabs: Tab[]): UseRingStack {
     expandedGroupIds: sanitized,
     rings,
     toggle,
+    expand,
     collapseAll,
   };
 }

--- a/src/donut/useRingStack.ts
+++ b/src/donut/useRingStack.ts
@@ -30,6 +30,15 @@ export interface UseRingStack {
   expand: (groupId: string, depth: number) => void;
   /** Colapsa todos os anéis externos. Equivale a expandedGroupIds = []. */
   collapseAll: () => void;
+  /** Issue #71 — trunca `expandedGroupIds` ao comprimento retornado por
+   *  `computeLen(current)`. Idempotente: se já está no tamanho alvo, não
+   *  dispara re-render. **Recebe função-updater** (não número direto)
+   *  porque hover-to-collapse e hover-to-expand frequentemente disparam
+   *  no mesmo commit cycle: o cálculo precisa rodar contra o `current`
+   *  pós-expand, não contra o snapshot stale do render anterior. Sem o
+   *  updater, `trim(0)` enfileirado depois de `expand("g",0)` anularia
+   *  o expand. Ver `useHoverToCollapse` pro caller real. */
+  trimToLength: (computeLen: (current: string[]) => number) => void;
 }
 
 /** Plano 23 / Issue #39 — máximo de anéis concêntricos (root + 1 sub-nível).
@@ -124,11 +133,22 @@ export function useRingStack(rootTabs: Tab[]): UseRingStack {
     setExpandedGroupIds((c) => (c.length === 0 ? c : []));
   }, []);
 
+  const trimToLength = useCallback(
+    (computeLen: (current: string[]) => number) => {
+      setExpandedGroupIds((c) => {
+        const clamped = Math.max(0, computeLen(c));
+        return c.length <= clamped ? c : c.slice(0, clamped);
+      });
+    },
+    [],
+  );
+
   return {
     expandedGroupIds: sanitized,
     rings,
     toggle,
     expand,
     collapseAll,
+    trimToLength,
   };
 }

--- a/src/entry/donut.tsx
+++ b/src/entry/donut.tsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { I18nextProvider, useTranslation } from "react-i18next";
 import i18next from "i18next";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { listen } from "@tauri-apps/api/event";
-import { Donut } from "../donut/Donut";
+import { Donut, type DonutHoverTarget } from "../donut/Donut";
 import { ScriptConfirmModal } from "../donut/ScriptConfirmModal";
 import { OnboardingHint } from "../donut/OnboardingHint";
-import { ipc, CONFIG_CHANGED_EVENT } from "../core/ipc";
+import { ipc, CONFIG_CHANGED_EVENT, SHORTCUT_RELEASED_EVENT } from "../core/ipc";
 import { initI18n, changeLanguage } from "../core/i18n";
 import { applyTokensAsCssVars, watchSystemTheme } from "../core/theme";
 import { resolveThemeTokens, type ThemeTokens } from "../core/themeTokens";
@@ -28,6 +28,13 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [scriptPrompt, setScriptPrompt] = useState<ScriptPrompt | null>(null);
   const [tokens, setTokens] = useState<ThemeTokens | undefined>(undefined);
+  // Issue #71 — refs (não state) pra que o listener do shortcut-released
+  // sempre leia os valores mais recentes sem re-bindar quando o cursor
+  // se mexe ou o config troca.
+  const hoverTargetRef = useRef<DonutHoverTarget>(null);
+  const configRef = useRef<Config | null>(initialConfig);
+  const handleSelectRef = useRef<(tabId: string) => void>(() => {});
+  const handleOpenSettingsRef = useRef<() => void>(() => {});
   // Plano 22 — `null` = ainda não consultado; `true` = mostra overlay;
   // `false` = launch normal (sem onboarding) ou já dispensado.
   const [showOnboarding, setShowOnboarding] = useState<boolean | null>(null);
@@ -120,6 +127,10 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
   }, []);
 
   useEffect(() => {
+    configRef.current = config;
+  }, [config]);
+
+  useEffect(() => {
     let unlisten: (() => void) | undefined;
     void listen<Config>(CONFIG_CHANGED_EVENT, (e) => {
       setConfig(e.payload);
@@ -132,6 +143,38 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
     return () => {
       unlisten?.();
     };
+  }, []);
+
+  // Issue #71 — modo rápido: ao soltar o atalho global o backend emite
+  // `shortcut-released`. Se houver tab sob o cursor, abre; senão só esconde
+  // o donut. Listener registrado apenas uma vez; refs cuidam de ler valores
+  // atuais.
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    void listen(SHORTCUT_RELEASED_EVENT, () => {
+      const cfg = configRef.current;
+      if (!cfg?.interaction.quickMode) return;
+      const target = hoverTargetRef.current;
+      if (target?.kind === "leaf") {
+        handleSelectRef.current(target.id);
+        return;
+      }
+      if (target?.kind === "gear") {
+        handleOpenSettingsRef.current();
+        return;
+      }
+      // `group` (drilling-só) ou `null` (fora de qualquer alvo): só
+      // esconde — modo rápido garante que soltar = donut some.
+      void ipc.hideDonut();
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+    // `handleSelect` é re-criado a cada render mas a referência via closure
+    // sempre lê o config atual via configRef; refs estabilizam o listener.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Plano 15: aplica tokens visuais como CSS vars sempre que o config muda
@@ -171,6 +214,10 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
       void ipc.hideDonut();
     }
   };
+
+  const handleHoverChange = useCallback((target: DonutHoverTarget) => {
+    hoverTargetRef.current = target;
+  }, []);
 
   const handleSelect = async (tabId: string) => {
     // Plano 22 — interagir = onboarding cumprido (user já entendeu o app).
@@ -245,6 +292,16 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
     }
   };
 
+  // Mantém o ref apontando para a versão atual de handleSelect; o listener
+  // de SHORTCUT_RELEASED_EVENT (registrado uma única vez) lê via ref pra
+  // não capturar uma closure antiga com `config`/`showOnboarding` stale.
+  handleSelectRef.current = (tabId: string) => {
+    void handleSelect(tabId);
+  };
+  handleOpenSettingsRef.current = () => {
+    void handleOpenSettings();
+  };
+
   const handleEditTab = (tabId: string) => {
     void handleOpenSettings(`edit-tab:${tabId}` as import("../core/ipc").SettingsIntent);
   };
@@ -299,6 +356,7 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
               onCreateProfile={() => {
                 void handleOpenSettings("new-profile");
               }}
+              onHoverChange={handleHoverChange}
             />
           );
         })()}

--- a/src/entry/donut.tsx
+++ b/src/entry/donut.tsx
@@ -5,6 +5,7 @@ import i18next from "i18next";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { listen } from "@tauri-apps/api/event";
 import { Donut, type DonutHoverTarget } from "../donut/Donut";
+import { decideQuickRelease } from "../donut/quickRelease";
 import { ScriptConfirmModal } from "../donut/ScriptConfirmModal";
 import { OnboardingHint } from "../donut/OnboardingHint";
 import { ipc, CONFIG_CHANGED_EVENT, SHORTCUT_RELEASED_EVENT } from "../core/ipc";
@@ -152,20 +153,23 @@ function App({ initialConfig }: { initialConfig: Config | null }) {
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     void listen(SHORTCUT_RELEASED_EVENT, () => {
-      const cfg = configRef.current;
-      if (!cfg?.interaction.quickMode) return;
-      const target = hoverTargetRef.current;
-      if (target?.kind === "leaf") {
-        handleSelectRef.current(target.id);
-        return;
+      const action = decideQuickRelease(
+        configRef.current,
+        hoverTargetRef.current,
+      );
+      switch (action.type) {
+        case "openTab":
+          handleSelectRef.current(action.tabId);
+          break;
+        case "openSettings":
+          handleOpenSettingsRef.current();
+          break;
+        case "hide":
+          void ipc.hideDonut();
+          break;
+        case "noop":
+          break;
       }
-      if (target?.kind === "gear") {
-        handleOpenSettingsRef.current();
-        return;
-      }
-      // `group` (drilling-só) ou `null` (fora de qualquer alvo): só
-      // esconde — modo rápido garante que soltar = donut some.
-      void ipc.hideDonut();
     }).then((fn) => {
       unlisten = fn;
     });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -159,6 +159,8 @@
       "spawnPositionCursor": "At the mouse position",
       "spawnPositionCenter": "Centered on the active monitor",
       "spawnPositionHint": "Sets the donut's starting point when you trigger the global shortcut.",
+      "quickModeLabel": "Quick mode (hold to show, release to open)",
+      "quickModeHint": "While enabled, the donut only stays visible while the global shortcut is held. Release the keys with the cursor over a tab to open it (or over the ⚙ to open settings).",
       "resetOnboardingButton": "Show welcome again",
       "resetOnboardingHint": "The welcome overlay reappears the next time you open DonutTabs manually.",
       "importConfirm": "Importing will replace your entire current configuration (profiles, tabs, shortcut, theme). Continue?",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -159,6 +159,8 @@
       "spawnPositionCursor": "Na posição do mouse",
       "spawnPositionCenter": "No centro do monitor ativo",
       "spawnPositionHint": "Define o ponto inicial do donut quando você dispara o atalho global.",
+      "quickModeLabel": "Modo rápido (segurar para mostrar, soltar para abrir)",
+      "quickModeHint": "Enquanto ativado, o donut só fica visível enquanto o atalho global está pressionado. Solte a tecla com o cursor sobre uma aba para abri-la (ou sobre o ⚙ para abrir as configurações).",
       "resetOnboardingButton": "Mostrar boas-vindas de novo",
       "resetOnboardingHint": "O overlay de boas-vindas reaparece na próxima vez que você abrir o DonutTabs manualmente.",
       "importConfirm": "Importar substitui toda a configuração atual (perfis, abas, atalho, tema). Continuar?",

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -127,6 +127,7 @@ export const SettingsApp: React.FC = () => {
     setAutoCheckUpdates,
     setScriptHistoryEnabled,
     setSpawnPosition,
+    setQuickMode,
   } = useConfig();
   const [section, setSection] = useState<Section>("tabs");
   const [selection, setSelection] = useState<Selection>({ mode: "empty" });
@@ -522,6 +523,12 @@ export const SettingsApp: React.FC = () => {
           spawnPosition={config.interaction.spawnPosition}
           onSpawnPositionChange={(position) => {
             void setSpawnPosition(position);
+          }}
+          quickMode={config.interaction.quickMode}
+          onQuickModeChange={(enabled) => {
+            void setQuickMode(enabled).catch((err) => {
+              window.alert(translateAppError(err, t));
+            });
           }}
           onResetOnboarding={() => {
             // Plano 22 — re-arma o overlay de boas-vindas pra próxima

--- a/src/settings/SystemSection.tsx
+++ b/src/settings/SystemSection.tsx
@@ -24,6 +24,10 @@ export interface SystemSectionProps {
   /** Issue #52: posição inicial do donut quando aberto pelo atalho. */
   spawnPosition?: SpawnPosition;
   onSpawnPositionChange?: (position: SpawnPosition) => void;
+  /** Issue #71: "modo rápido" — donut visível enquanto o atalho está
+   *  pressionado; soltar abre a aba sob o cursor. */
+  quickMode?: boolean;
+  onQuickModeChange?: (enabled: boolean) => void;
   /** Plano 22: re-armar tutorial de boas-vindas na próxima manual launch.
    *  Quando ausente, o botão não renderiza. */
   onResetOnboarding?: () => void;
@@ -42,6 +46,8 @@ export const SystemSection: React.FC<SystemSectionProps> = ({
   onScriptHistoryEnabledChange,
   spawnPosition,
   onSpawnPositionChange,
+  quickMode,
+  onQuickModeChange,
   onResetOnboarding,
 }) => {
   const { t } = useTranslation();
@@ -112,44 +118,65 @@ export const SystemSection: React.FC<SystemSectionProps> = ({
         </div>
       </fieldset>
 
-      {/* Donut: posição de spawn. */}
-      {spawnPosition !== undefined && onSpawnPositionChange && (
+      {/* Donut: posição de spawn + modo rápido. */}
+      {((spawnPosition !== undefined && onSpawnPositionChange) ||
+        (quickMode !== undefined && onQuickModeChange)) && (
         <fieldset style={groupStyle}>
           <legend style={legendStyle}>
             {t("settings.system.groups.donut")}
           </legend>
-          <div role="group" aria-label={t("settings.system.spawnPositionLegend")}>
-            <div style={{ marginBottom: 4, fontSize: 14 }}>
-              {t("settings.system.spawnPositionLegend")}
+          {spawnPosition !== undefined && onSpawnPositionChange && (
+            <div role="group" aria-label={t("settings.system.spawnPositionLegend")}>
+              <div style={{ marginBottom: 4, fontSize: 14 }}>
+                {t("settings.system.spawnPositionLegend")}
+              </div>
+              <label
+                style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
+              >
+                <input
+                  type="radio"
+                  name="spawn-position"
+                  data-testid="spawn-position-cursor"
+                  checked={spawnPosition === "cursor"}
+                  onChange={() => onSpawnPositionChange("cursor")}
+                />
+                {t("settings.system.spawnPositionCursor")}
+              </label>
+              <label
+                style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
+              >
+                <input
+                  type="radio"
+                  name="spawn-position"
+                  data-testid="spawn-position-center"
+                  checked={spawnPosition === "center"}
+                  onChange={() => onSpawnPositionChange("center")}
+                />
+                {t("settings.system.spawnPositionCenter")}
+              </label>
+              <small style={{ color: "var(--muted)", display: "block", paddingTop: 4 }}>
+                {t("settings.system.spawnPositionHint")}
+              </small>
             </div>
-            <label
-              style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
-            >
-              <input
-                type="radio"
-                name="spawn-position"
-                data-testid="spawn-position-cursor"
-                checked={spawnPosition === "cursor"}
-                onChange={() => onSpawnPositionChange("cursor")}
-              />
-              {t("settings.system.spawnPositionCursor")}
-            </label>
-            <label
-              style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
-            >
-              <input
-                type="radio"
-                name="spawn-position"
-                data-testid="spawn-position-center"
-                checked={spawnPosition === "center"}
-                onChange={() => onSpawnPositionChange("center")}
-              />
-              {t("settings.system.spawnPositionCenter")}
-            </label>
-            <small style={{ color: "var(--muted)", display: "block", paddingTop: 4 }}>
-              {t("settings.system.spawnPositionHint")}
-            </small>
-          </div>
+          )}
+          {quickMode !== undefined && onQuickModeChange && (
+            <div>
+              <label
+                style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
+              >
+                <input
+                  type="checkbox"
+                  data-testid="quick-mode-toggle"
+                  checked={quickMode}
+                  onChange={(e) => onQuickModeChange(e.target.checked)}
+                />
+                {t("settings.system.quickModeLabel")}
+              </label>
+              <small style={{ color: "var(--muted)", display: "block", paddingLeft: 26 }}>
+                {t("settings.system.quickModeHint")}
+              </small>
+            </div>
+          )}
         </fieldset>
       )}
 

--- a/src/settings/__tests__/SystemSection.test.tsx
+++ b/src/settings/__tests__/SystemSection.test.tsx
@@ -17,6 +17,8 @@ async function renderSection(overrides: Partial<{
   onAllowScriptsChange: (a: boolean) => void;
   scriptHistoryEnabled: boolean;
   onScriptHistoryEnabledChange: (e: boolean) => void;
+  quickMode: boolean;
+  onQuickModeChange: (e: boolean) => void;
 }> = {}) {
   const i18n = await createI18n("pt-BR");
   const props = {
@@ -107,5 +109,26 @@ describe("SystemSection", () => {
   it("Issue #54 (rev) — does not render the script-history toggle when prop missing", async () => {
     await renderSection();
     expect(screen.queryByTestId("script-history-toggle")).toBeNull();
+  });
+
+  it("Issue #71 — quick-mode toggle reflects current value", async () => {
+    await renderSection({ quickMode: true, onQuickModeChange: vi.fn() });
+    const cb = screen.getByTestId("quick-mode-toggle") as HTMLInputElement;
+    expect(cb.checked).toBe(true);
+  });
+
+  it("Issue #71 — toggling the quick-mode checkbox calls the handler", async () => {
+    const user = userEvent.setup();
+    const { props } = await renderSection({
+      quickMode: false,
+      onQuickModeChange: vi.fn(),
+    });
+    await user.click(screen.getByTestId("quick-mode-toggle"));
+    expect(props.onQuickModeChange).toHaveBeenCalledWith(true);
+  });
+
+  it("Issue #71 — does not render the quick-mode toggle when prop missing", async () => {
+    await renderSection();
+    expect(screen.queryByTestId("quick-mode-toggle")).toBeNull();
   });
 });

--- a/src/settings/useConfig.ts
+++ b/src/settings/useConfig.ts
@@ -51,6 +51,7 @@ export interface UseConfig {
   setAutoCheckUpdates: (enabled: boolean) => Promise<Config>;
   setScriptHistoryEnabled: (enabled: boolean) => Promise<Config>;
   setSpawnPosition: (position: SpawnPosition) => Promise<Config>;
+  setQuickMode: (enabled: boolean) => Promise<Config>;
 }
 
 export function useConfig(): UseConfig {
@@ -234,6 +235,12 @@ export function useConfig(): UseConfig {
     return next;
   }, []);
 
+  const setQuickMode = useCallback(async (enabled: boolean) => {
+    const next = await ipc.setQuickMode(enabled);
+    setConfig(next);
+    return next;
+  }, []);
+
   return {
     config,
     loadError,
@@ -256,5 +263,6 @@ export function useConfig(): UseConfig {
     setAutoCheckUpdates,
     setScriptHistoryEnabled,
     setSpawnPosition,
+    setQuickMode,
   };
 }


### PR DESCRIPTION
## Summary

- **Modo rápido** (toggle em Configurações → Sistema → Donut): quando ligado, o donut só fica visível enquanto o atalho global está pressionado. Soltar a tecla com o cursor sobre uma aba abre-a; sobre o ⚙ abre as configurações; sobre um group (ou fora) só esconde o donut.
- **Hover-to-expand** universal: passar o cursor sobre um group expande o sub-anel instantaneamente — independente do modo rápido. Click no group continua sendo o gesto de fechar (toggle).
- Backend: `shortcut::bind` agora trata `ShortcutState::Released` e, quando `interaction.quick_mode == true`, emite `shortcut-released` pra janela do donut. Novo command `set_quick_mode` + helper puro `apply_set_quick_mode` (testado). Schema ganhou `Interaction.quick_mode: bool` (default `false`, configs Plano-23 e anteriores deserializam sem migração).
- Frontend: `<Donut>` expõe `onHoverChange(target: DonutHoverTarget)` com union tipado (`leaf | group | gear | null`). Entry usa refs pra um listener único de `shortcut-released` que despacha conforme o `kind`. `useRingStack` ganhou método idempotente `expand(groupId, depth)` — diferente de `toggle`, não fecha ao re-chamar.
- Resolve #71.

## Test plan

- [ ] `cargo test --lib` (425 ok local)
- [ ] `npm test` (484 ok local)
- [ ] `npx tsc --noEmit` (limpo)
- [ ] Smoke manual no macOS:
  - [ ] Toggle off (default): comportamento click-to-open inalterado
  - [ ] Toggle on: segurar atalho → donut aparece; soltar sobre aba leaf → abre; sobre ⚙ → abre Settings; sobre group ou fora → só esconde
  - [ ] Hover sobre group expande sub-anel; clicar no group expandido fecha
- [ ] Smoke manual no Windows/Linux se possível

🤖 Generated with [Claude Code](https://claude.com/claude-code)