### PR TITLE
feat(shortcut): atalho global para Settings + gate de gravação (#66, #80)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9,11 +9,12 @@ use crate::launcher::{launch_tab, ScriptCaptureExecutor, TauriOpener};
 use crate::script_history::{
     ScriptHistory, ScriptRun, ScriptRunSummary, ScriptStatus, ScriptStream,
 };
-use crate::shortcut::{self, ActiveShortcut};
+use crate::shortcut::{self, ActiveSettingsShortcut, ActiveShortcut};
 use crate::updater::{self, UpdateSummary};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use tauri::{Emitter, Manager};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
@@ -46,6 +47,14 @@ pub struct AppState {
     pub pending_settings_intent: Mutex<Option<String>>,
     /// Atalho global atualmente registrado.
     pub active_shortcut: ActiveShortcut,
+    /// Issue #66 — atalho global que abre Settings direto.
+    pub active_settings_shortcut: ActiveSettingsShortcut,
+    /// Issue #80 — `true` enquanto algum `<ShortcutRecorder>` no Settings
+    /// está capturando keys. Gates os handlers globais (donut + settings)
+    /// pra evitar abrir janelas por cima do form de captura. Transiente,
+    /// não persiste em disco. Atomic permite leitura lock-free dentro do
+    /// callback do plugin-global-shortcut.
+    pub recording_shortcut: AtomicBool,
     /// Plano 18 — populated pelo task de startup quando há update
     /// pendente. Frontend lê via `get_pending_update`.
     pub pending_update: RwLock<Option<UpdateSummary>>,
@@ -681,6 +690,51 @@ pub fn set_search_shortcut<R: tauri::Runtime>(
     };
     let _ = app.emit(CONFIG_CHANGED_EVENT, &snapshot);
     Ok(snapshot)
+}
+
+/// Issue #66 — atualiza o atalho global que abre Settings. Re-registra
+/// conflict-aware (registra novo antes de desregistrar antigo) e persiste
+/// com rollback (se save_atomic falhar, restaura o atalho anterior tanto
+/// em memória quanto no SO).
+#[tauri::command]
+pub fn set_settings_shortcut<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    combo: String,
+) -> Result<Config, AppError> {
+    if combo.trim().is_empty() {
+        return Err(AppError::config("settings_shortcut_empty", &[]));
+    }
+    crate::shortcut::set_settings_from_config(&app, &state.active_settings_shortcut, &combo)?;
+
+    let snapshot = {
+        let mut cfg = state.config.write().unwrap();
+        let old = cfg.interaction.settings_shortcut.clone();
+        cfg.interaction.settings_shortcut = combo;
+        if let Err(e) = save_atomic(&state.config_path, &cfg) {
+            // Rollback duplo: memória + SO. Se o SO falhar no rollback,
+            // ainda assim retornamos o erro original do save_atomic.
+            cfg.interaction.settings_shortcut = old.clone();
+            let _ = crate::shortcut::set_settings_from_config(
+                &app,
+                &state.active_settings_shortcut,
+                &old,
+            );
+            return Err(e);
+        }
+        cfg.clone()
+    };
+    let _ = app.emit(CONFIG_CHANGED_EVENT, &snapshot);
+    Ok(snapshot)
+}
+
+/// Issue #80 — sinaliza ao backend que algum `<ShortcutRecorder>` está
+/// ativo. Enquanto `true`, os handlers globais de atalho (donut e Settings)
+/// fazem early-return em vez de abrir janela. Estado transiente (não
+/// persiste), atomic pra leitura lock-free no callback.
+#[tauri::command]
+pub fn set_recording_shortcut(state: tauri::State<'_, AppState>, recording: bool) {
+    state.recording_shortcut.store(recording, Ordering::Relaxed);
 }
 
 /// Plano 23 — toggle do gap angular entre slices vizinhos no donut.
@@ -1329,6 +1383,8 @@ pub fn initial_load(config_path: PathBuf) -> AppResult<AppState> {
         config_path,
         pending_settings_intent: Mutex::new(None),
         active_shortcut: ActiveShortcut::default(),
+        active_settings_shortcut: ActiveSettingsShortcut::default(),
+        recording_shortcut: AtomicBool::new(false),
         pending_update: RwLock::new(None),
         script_history: Arc::new(ScriptHistory::new()),
         script_children: Arc::new(Mutex::new(HashMap::new())),

--- a/src-tauri/src/config/migrate.rs
+++ b/src-tauri/src/config/migrate.rs
@@ -69,6 +69,7 @@ mod tests {
                 selection_mode: SelectionMode::ClickOrRelease,
                 hover_hold_ms: 800,
                 search_shortcut: "CommandOrControl+F".into(),
+                settings_shortcut: "CommandOrControl+Shift+,".into(),
                 slice_gap_enabled: true,
                 quick_mode: false,
             },

--- a/src-tauri/src/config/schema.rs
+++ b/src-tauri/src/config/schema.rs
@@ -128,6 +128,11 @@ pub struct Interaction {
     /// anteriores deserializam usando `default_search_shortcut`.
     #[serde(default = "default_search_shortcut")]
     pub search_shortcut: String,
+    /// Issue #66 — atalho global que abre a janela de Settings direto, sem
+    /// passar pelo donut/tray. Formato Tauri (`CommandOrControl+Shift+,`).
+    /// Configs anteriores deserializam usando `default_settings_shortcut`.
+    #[serde(default = "default_settings_shortcut")]
+    pub settings_shortcut: String,
     /// Plano 23 — quando `true` (default), o donut pinta gap angular
     /// entre slices vizinhos. Quando `false`, slices ficam coladas (look
     /// original Plano 16). Configs anteriores deserializam como `true`
@@ -146,6 +151,10 @@ pub struct Interaction {
 
 fn default_search_shortcut() -> String {
     "CommandOrControl+F".to_string()
+}
+
+fn default_settings_shortcut() -> String {
+    "CommandOrControl+Shift+,".to_string()
 }
 
 fn default_slice_gap_enabled() -> bool {
@@ -402,6 +411,7 @@ impl Default for Config {
                 selection_mode: SelectionMode::ClickOrRelease,
                 hover_hold_ms: 1200,
                 search_shortcut: default_search_shortcut(),
+                settings_shortcut: default_settings_shortcut(),
                 slice_gap_enabled: default_slice_gap_enabled(),
                 quick_mode: false,
             },
@@ -1043,6 +1053,7 @@ mod tests {
             selection_mode: SelectionMode::ClickOrRelease,
             hover_hold_ms: 1200,
             search_shortcut: "CommandOrControl+F".into(),
+            settings_shortcut: "CommandOrControl+Shift+,".into(),
             slice_gap_enabled: false,
             quick_mode: false,
         };
@@ -1076,6 +1087,7 @@ mod tests {
             selection_mode: SelectionMode::ClickOrRelease,
             hover_hold_ms: 1200,
             search_shortcut: "CommandOrControl+F".into(),
+            settings_shortcut: "CommandOrControl+Shift+,".into(),
             slice_gap_enabled: true,
             quick_mode: true,
         };
@@ -1095,6 +1107,49 @@ mod tests {
     fn default_config_enables_slice_gap() {
         let cfg = Config::default();
         assert!(cfg.interaction.slice_gap_enabled);
+    }
+
+    // ---------- Issue #66: Interaction.settings_shortcut ----------
+
+    #[test]
+    fn interaction_defaults_settings_shortcut_when_absent() {
+        // Configs anteriores ao #66 não têm o campo. Precisa virar o default.
+        let json = r#"{
+            "spawnPosition": "cursor",
+            "selectionMode": "clickOrRelease",
+            "hoverHoldMs": 1200,
+            "searchShortcut": "CommandOrControl+F",
+            "sliceGapEnabled": true,
+            "quickMode": false
+        }"#;
+        let i: Interaction = serde_json::from_str(json).unwrap();
+        assert_eq!(i.settings_shortcut, "CommandOrControl+Shift+,");
+    }
+
+    #[test]
+    fn interaction_round_trip_with_settings_shortcut() {
+        let i = Interaction {
+            spawn_position: SpawnPosition::Cursor,
+            selection_mode: SelectionMode::ClickOrRelease,
+            hover_hold_ms: 1200,
+            search_shortcut: "CommandOrControl+F".into(),
+            settings_shortcut: "CommandOrControl+Alt+S".into(),
+            slice_gap_enabled: true,
+            quick_mode: false,
+        };
+        let json = serde_json::to_string(&i).unwrap();
+        assert!(json.contains("\"settingsShortcut\":\"CommandOrControl+Alt+S\""));
+        let back: Interaction = serde_json::from_str(&json).unwrap();
+        assert_eq!(i, back);
+    }
+
+    #[test]
+    fn default_config_has_settings_shortcut_default() {
+        let cfg = Config::default();
+        assert_eq!(
+            cfg.interaction.settings_shortcut,
+            "CommandOrControl+Shift+,"
+        );
     }
 
     // ---------- Plano 22: SystemConfig.first_launch_completed ----------

--- a/src-tauri/src/config/validate.rs
+++ b/src-tauri/src/config/validate.rs
@@ -27,6 +27,11 @@ pub fn validate(config: &Config) -> AppResult<()> {
     }
     shortcut::validate_combo(&config.interaction.search_shortcut)?;
 
+    if config.interaction.settings_shortcut.trim().is_empty() {
+        return Err(AppError::config("settings_shortcut_empty", &[]));
+    }
+    shortcut::validate_combo(&config.interaction.settings_shortcut)?;
+
     if config.profiles.is_empty() {
         return Err(AppError::config("no_profiles", &[]));
     }
@@ -820,6 +825,30 @@ mod tests {
         let mut cfg = base_config();
         cfg.interaction.search_shortcut = "garbage".into();
         // `validate_combo` propaga `shortcut_parse_failed`.
+        match validate(&cfg).unwrap_err() {
+            AppError::Shortcut { code, .. } => assert_eq!(code, "shortcut_parse_failed"),
+            other => panic!("expected Shortcut error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn settings_shortcut_empty_is_rejected() {
+        let mut cfg = base_config();
+        cfg.interaction.settings_shortcut = "".into();
+        assert_config_code(validate(&cfg).unwrap_err(), "settings_shortcut_empty");
+    }
+
+    #[test]
+    fn settings_shortcut_whitespace_is_rejected() {
+        let mut cfg = base_config();
+        cfg.interaction.settings_shortcut = "   ".into();
+        assert_config_code(validate(&cfg).unwrap_err(), "settings_shortcut_empty");
+    }
+
+    #[test]
+    fn settings_shortcut_garbage_is_rejected() {
+        let mut cfg = base_config();
+        cfg.interaction.settings_shortcut = "lkj".into();
         match validate(&cfg).unwrap_err() {
             AppError::Shortcut { code, .. } => assert_eq!(code, "shortcut_parse_failed"),
             other => panic!("expected Shortcut error, got {other:?}"),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -116,6 +116,10 @@ pub fn run() {
                     .map(|p| p.shortcut.clone())
                     .unwrap_or_else(|| "CommandOrControl+Shift+Space".into())
             };
+            let settings_shortcut_str = {
+                let cfg = state.config.read().unwrap();
+                cfg.interaction.settings_shortcut.clone()
+            };
             app.manage(state);
 
             tray::setup(app).map_err(|e| format!("tray: {e}"))?;
@@ -133,6 +137,18 @@ pub fn run() {
                 ) {
                     eprintln!(
                         "[setup] shortcut registration failed ({e:?}); the global shortcut will be unavailable until the app is restarted"
+                    );
+                }
+                // Issue #66 — segundo atalho global, abre Settings direto.
+                // Best-effort igual ao do donut: falha (combo em uso por outro
+                // app) loga e segue; user pode reconfigurar via Settings.
+                if let Err(e) = shortcut::register_settings_from_config(
+                    app.handle(),
+                    &state.active_settings_shortcut,
+                    &settings_shortcut_str,
+                ) {
+                    eprintln!(
+                        "[setup] settings shortcut registration failed ({e:?}); user can reconfigure in Settings"
                     );
                 }
             }
@@ -252,6 +268,8 @@ pub fn run() {
             commands::export_config,
             commands::import_config,
             commands::set_search_shortcut,
+            commands::set_settings_shortcut,
+            commands::set_recording_shortcut,
             commands::set_slice_gap_enabled,
             commands::set_quick_mode,
             commands::set_spawn_position,

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -1,5 +1,7 @@
 use crate::donut_window;
 use crate::errors::{AppError, AppResult};
+use crate::settings_window;
+use std::sync::atomic::Ordering;
 use std::sync::Mutex;
 use tauri::{AppHandle, Emitter, Manager, Runtime};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
@@ -17,6 +19,17 @@ pub struct ActiveShortcut(pub Mutex<Option<Shortcut>>);
 impl Default for ActiveShortcut {
     fn default() -> Self {
         ActiveShortcut(Mutex::new(None))
+    }
+}
+
+/// Issue #66 — atalho global que abre direto a janela de Settings. Vive em
+/// `AppState` junto com `ActiveShortcut` do donut e segue o mesmo padrão
+/// conflict-aware via `set_settings_from_config`.
+pub struct ActiveSettingsShortcut(pub Mutex<Option<Shortcut>>);
+
+impl Default for ActiveSettingsShortcut {
+    fn default() -> Self {
+        ActiveSettingsShortcut(Mutex::new(None))
     }
 }
 
@@ -109,6 +122,12 @@ fn bind<R: Runtime>(app: &AppHandle<R>, sc: &Shortcut) -> AppResult<()> {
     app.global_shortcut()
         .on_shortcut(*sc, move |_app, _sc, event| match event.state() {
             ShortcutState::Pressed => {
+                // Issue #80 — quando o usuário está gravando um atalho no
+                // Settings, suprimir o donut. Sem isso a tecla pressionada
+                // abriria o donut por cima do form de captura.
+                if is_recording(&app_for_handler) {
+                    return;
+                }
                 let _ = donut_window::show(&app_for_handler);
             }
             ShortcutState::Released => {
@@ -117,6 +136,9 @@ fn bind<R: Runtime>(app: &AppHandle<R>, sc: &Shortcut) -> AppResult<()> {
                 // state (cenário raro de setup parcial) é silenciada — o
                 // atalho já funcionou no Pressed, soltar sem efeito é
                 // fail-safe.
+                if is_recording(&app_for_handler) {
+                    return;
+                }
                 let state: tauri::State<'_, crate::commands::AppState> = app_for_handler.state();
                 let quick_mode = state.config.read().unwrap().interaction.quick_mode;
                 if quick_mode {
@@ -130,4 +152,69 @@ fn bind<R: Runtime>(app: &AppHandle<R>, sc: &Shortcut) -> AppResult<()> {
                 &[("combo", format!("{sc:?}")), ("reason", e.to_string())],
             )
         })
+}
+
+/// Issue #66 — registra o atalho global que abre Settings. Espelha
+/// `register_from_config` (donut) mas com handler que chama
+/// `settings_window::show` e sem evento de release (Settings é decorated,
+/// não tem comportamento quick_mode).
+pub fn register_settings_from_config<R: Runtime>(
+    app: &AppHandle<R>,
+    active: &ActiveSettingsShortcut,
+    shortcut_str: &str,
+) -> AppResult<()> {
+    let shortcut = parse(shortcut_str)?;
+    bind_settings(app, &shortcut)?;
+    *active.0.lock().unwrap() = Some(shortcut);
+    Ok(())
+}
+
+/// Issue #66 — swap conflict-aware do atalho de Settings. Mesma semântica
+/// do `set_from_config` (donut): registra o novo antes de desregistrar o
+/// antigo, então uma falha não derruba o atalho atual.
+pub fn set_settings_from_config<R: Runtime>(
+    app: &AppHandle<R>,
+    active: &ActiveSettingsShortcut,
+    new_combo: &str,
+) -> AppResult<()> {
+    let new_sc = parse(new_combo)?;
+    {
+        let slot = active.0.lock().unwrap();
+        if slot.as_ref() == Some(&new_sc) {
+            return Ok(());
+        }
+    }
+    bind_settings(app, &new_sc)?;
+    let mut slot = active.0.lock().unwrap();
+    if let Some(old) = slot.take() {
+        let _ = app.global_shortcut().unregister(old);
+    }
+    *slot = Some(new_sc);
+    Ok(())
+}
+
+fn bind_settings<R: Runtime>(app: &AppHandle<R>, sc: &Shortcut) -> AppResult<()> {
+    let app_for_handler = app.clone();
+    app.global_shortcut()
+        .on_shortcut(*sc, move |_app, _sc, event| {
+            if event.state() != ShortcutState::Pressed {
+                return;
+            }
+            // Issue #80 — gate igual ao do donut handler.
+            if is_recording(&app_for_handler) {
+                return;
+            }
+            let _ = settings_window::show(&app_for_handler);
+        })
+        .map_err(|e| {
+            AppError::shortcut(
+                "shortcut_registration_failed",
+                &[("combo", format!("{sc:?}")), ("reason", e.to_string())],
+            )
+        })
+}
+
+fn is_recording<R: Runtime>(app: &AppHandle<R>) -> bool {
+    let state: tauri::State<'_, crate::commands::AppState> = app.state();
+    state.recording_shortcut.load(Ordering::Relaxed)
 }

--- a/src/core/ipc.ts
+++ b/src/core/ipc.ts
@@ -85,6 +85,15 @@ export const ipc = {
     invoke<ImportResult>("import_config", { sourcePath }),
   setSearchShortcut: (combo: string) =>
     invoke<Config>("set_search_shortcut", { combo }),
+  /** Issue #66 — atalho global que abre Settings direto. Re-registra no
+   *  SO conflict-aware; combos inválidos voltam como `AppError`. */
+  setSettingsShortcut: (combo: string) =>
+    invoke<Config>("set_settings_shortcut", { combo }),
+  /** Issue #80 — sinaliza ao backend que algum `<ShortcutRecorder>` está
+   *  capturando teclas. Enquanto `true`, os handlers globais (donut +
+   *  settings) ignoram o press pra não abrir janela por cima do form. */
+  setRecordingShortcut: (recording: boolean) =>
+    invoke<void>("set_recording_shortcut", { recording }),
   /** Plano 23 — toggle do gap angular entre slices vizinhos no donut.
    *  Mora em `interaction.sliceGapEnabled` (global, não per-perfil). */
   setSliceGapEnabled: (enabled: boolean) =>

--- a/src/core/types/Interaction.ts
+++ b/src/core/types/Interaction.ts
@@ -10,6 +10,12 @@ export type Interaction = { spawnPosition: SpawnPosition, selectionMode: Selecti
  */
 searchShortcut: string, 
 /**
+ * Issue #66 — atalho global que abre a janela de Settings direto, sem
+ * passar pelo donut/tray. Formato Tauri (`CommandOrControl+Shift+,`).
+ * Configs anteriores deserializam usando `default_settings_shortcut`.
+ */
+settingsShortcut: string, 
+/**
  * Plano 23 — quando `true` (default), o donut pinta gap angular
  * entre slices vizinhos. Quando `false`, slices ficam coladas (look
  * original Plano 16). Configs anteriores deserializam como `true`

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -20,6 +20,7 @@
       "themeRadiusOutOfRange": "Invalid radius in {{field}}: {{value}}. Out of allowed range.",
       "themeRadiusInverted": "Inner radius must be smaller than outer radius.",
       "searchShortcutEmpty": "Search shortcut cannot be empty.",
+      "settingsShortcutEmpty": "Settings shortcut cannot be empty.",
       "noProfiles": "Invalid config: no profiles defined.",
       "activeProfileNotFound": "Active profile not found: {{activeProfileId}}",
       "duplicateProfileId": "Duplicate profile id: {{id}}",
@@ -265,7 +266,9 @@
       "reservedKey": "Reserved key: {{key}}",
       "noModifier": "A standalone letter or digit ({{key}}) would hijack the key in every app. Add Ctrl/Alt/Shift/Super, or use F1–F12.",
       "searchSectionTitle": "Search shortcut",
-      "searchHint": "Window-level shortcut that opens the quick tab search inside the donut. Default: Ctrl+F."
+      "searchHint": "Window-level shortcut that opens the quick tab search inside the donut. Default: Ctrl+F.",
+      "settingsSectionTitle": "Settings shortcut",
+      "settingsHint": "Global shortcut that opens the Settings window directly, bypassing the donut. Default: Ctrl+Shift+,."
     },
     "tabs": {
       "sectionTitle": "Tabs",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -20,6 +20,7 @@
       "themeRadiusOutOfRange": "Raio inválido em {{field}}: {{value}}. Fora dos limites permitidos.",
       "themeRadiusInverted": "Raio interno deve ser menor que raio externo.",
       "searchShortcutEmpty": "Atalho de busca não pode ser vazio.",
+      "settingsShortcutEmpty": "Atalho de configurações não pode ser vazio.",
       "noProfiles": "Configuração inválida: nenhum perfil cadastrado.",
       "activeProfileNotFound": "Perfil ativo não encontrado: {{activeProfileId}}",
       "duplicateProfileId": "ID de perfil duplicado: {{id}}",
@@ -265,7 +266,9 @@
       "reservedKey": "Tecla reservada: {{key}}",
       "noModifier": "Letra ou dígito sozinho ({{key}}) bloqueia a tecla em qualquer app. Adicione Ctrl/Alt/Shift/Super, ou use F1–F12.",
       "searchSectionTitle": "Atalho de busca",
-      "searchHint": "Atalho dentro do donut que abre a busca rápida de abas. Padrão: Ctrl+F."
+      "searchHint": "Atalho dentro do donut que abre a busca rápida de abas. Padrão: Ctrl+F.",
+      "settingsSectionTitle": "Atalho de configurações",
+      "settingsHint": "Atalho global que abre direto a janela de configurações, sem passar pelo donut. Padrão: Ctrl+Shift+,."
     },
     "tabs": {
       "sectionTitle": "Abas",

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -122,6 +122,7 @@ export const SettingsApp: React.FC = () => {
     reorderTabs,
     reorderProfiles,
     setSearchShortcut,
+    setSettingsShortcut,
     setProfileAllowScripts,
     setProfileThemeOverrides,
     setAutoCheckUpdates,
@@ -567,6 +568,10 @@ export const SettingsApp: React.FC = () => {
           searchShortcut={config.interaction.searchShortcut}
           onCaptureSearchShortcut={async (combo) => {
             await setSearchShortcut(combo);
+          }}
+          settingsShortcut={config.interaction.settingsShortcut}
+          onCaptureSettingsShortcut={async (combo) => {
+            await setSettingsShortcut(combo);
           }}
         />
       )}

--- a/src/settings/ShortcutRecorder.tsx
+++ b/src/settings/ShortcutRecorder.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { buildCombo } from "./buildCombo";
+import { ipc } from "../core/ipc";
 
 export interface ShortcutRecorderProps {
   current: string;
@@ -17,6 +18,11 @@ export const ShortcutRecorder: React.FC<ShortcutRecorderProps> = ({
 
   useEffect(() => {
     if (!recording) return;
+
+    // Issue #80 — sinaliza ao backend pra suprimir os handlers globais
+    // (donut/settings) enquanto o usuário está pressionando teclas.
+    // Cleanup garante reset mesmo em unmount/erro/Esc.
+    void ipc.setRecordingShortcut(true);
 
     const handler = (e: KeyboardEvent) => {
       e.preventDefault();
@@ -46,8 +52,18 @@ export const ShortcutRecorder: React.FC<ShortcutRecorderProps> = ({
       // pressionado). Espera a próxima tecla.
     };
 
+    // Reforço defensivo: se a janela perde foco (alt-tab, dock click, etc.)
+    // enquanto o user está gravando, sai do recording. Sem isso o flag
+    // backend ficaria stuck até unmount do componente.
+    const onBlur = () => setRecording(false);
+
     window.addEventListener("keydown", handler, { capture: true });
-    return () => window.removeEventListener("keydown", handler, { capture: true });
+    window.addEventListener("blur", onBlur);
+    return () => {
+      window.removeEventListener("keydown", handler, { capture: true });
+      window.removeEventListener("blur", onBlur);
+      void ipc.setRecordingShortcut(false);
+    };
   }, [recording, t, onCapture]);
 
   const buttonStyle: React.CSSProperties = {

--- a/src/settings/ShortcutSection.tsx
+++ b/src/settings/ShortcutSection.tsx
@@ -8,6 +8,8 @@ export interface ShortcutSectionProps {
   onCapture: (combo: string) => Promise<void>;
   searchShortcut: string;
   onCaptureSearchShortcut: (combo: string) => Promise<void>;
+  settingsShortcut: string;
+  onCaptureSettingsShortcut: (combo: string) => Promise<void>;
 }
 
 export const ShortcutSection: React.FC<ShortcutSectionProps> = ({
@@ -15,10 +17,13 @@ export const ShortcutSection: React.FC<ShortcutSectionProps> = ({
   onCapture,
   searchShortcut,
   onCaptureSearchShortcut,
+  settingsShortcut,
+  onCaptureSettingsShortcut,
 }) => {
   const { t } = useTranslation();
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [searchError, setSearchError] = useState<string | null>(null);
+  const [settingsError, setSettingsError] = useState<string | null>(null);
 
   const handleCaptureGlobal = async (combo: string) => {
     setGlobalError(null);
@@ -35,6 +40,15 @@ export const ShortcutSection: React.FC<ShortcutSectionProps> = ({
       await onCaptureSearchShortcut(combo);
     } catch (err) {
       setSearchError(translateAppError(err, t));
+    }
+  };
+
+  const handleCaptureSettings = async (combo: string) => {
+    setSettingsError(null);
+    try {
+      await onCaptureSettingsShortcut(combo);
+    } catch (err) {
+      setSettingsError(translateAppError(err, t));
     }
   };
 
@@ -85,6 +99,36 @@ export const ShortcutSection: React.FC<ShortcutSectionProps> = ({
         {searchError && (
           <div role="alert" style={{ color: "var(--danger-fg)" }}>
             {searchError}
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+          paddingTop: 16,
+          borderTop: "1px solid var(--input-border)",
+        }}
+      >
+        <div>
+          <h3 style={{ margin: 0, fontSize: 16 }}>
+            {t("settings.shortcut.settingsSectionTitle")}
+          </h3>
+          <small style={{ color: "var(--muted)" }}>
+            {t("settings.shortcut.settingsHint")}
+          </small>
+        </div>
+        <div data-testid="settings-shortcut-recorder">
+          <ShortcutRecorder
+            current={settingsShortcut}
+            onCapture={handleCaptureSettings}
+          />
+        </div>
+        {settingsError && (
+          <div role="alert" style={{ color: "var(--danger-fg)" }}>
+            {settingsError}
           </div>
         )}
       </div>

--- a/src/settings/__tests__/ShortcutRecorder.test.tsx
+++ b/src/settings/__tests__/ShortcutRecorder.test.tsx
@@ -1,9 +1,21 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nextProvider } from "react-i18next";
 import { createI18n } from "../../core/i18n";
+
+vi.mock("../../core/ipc", () => ({
+  ipc: {
+    setRecordingShortcut: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { ipc } from "../../core/ipc";
 import { ShortcutRecorder } from "../ShortcutRecorder";
+
+beforeEach(() => {
+  vi.mocked(ipc.setRecordingShortcut).mockClear();
+});
 
 async function renderRecorder(overrides: Partial<{
   current: string;
@@ -105,5 +117,48 @@ describe("ShortcutRecorder", () => {
     expect(screen.queryByRole("alert")).toBeNull();
     expect(props.onCapture).not.toHaveBeenCalled();
     expect(screen.getByText(/pressione a combinação/i)).toBeTruthy();
+  });
+
+  // Issue #80 — gating do donut/settings shortcut enquanto user grava.
+  it("calls setRecordingShortcut(true) when entering recording", async () => {
+    const user = userEvent.setup();
+    await renderRecorder();
+    await user.click(screen.getByRole("button", { name: /gravar novo atalho/i }));
+
+    expect(ipc.setRecordingShortcut).toHaveBeenCalledWith(true);
+  });
+
+  it("calls setRecordingShortcut(false) on capture (cleanup runs)", async () => {
+    const user = userEvent.setup();
+    await renderRecorder();
+    await user.click(screen.getByRole("button", { name: /gravar novo atalho/i }));
+
+    vi.mocked(ipc.setRecordingShortcut).mockClear();
+    fireEvent.keyDown(window, { key: "D", ctrlKey: true, shiftKey: true });
+
+    expect(ipc.setRecordingShortcut).toHaveBeenCalledWith(false);
+  });
+
+  it("calls setRecordingShortcut(false) on Escape cancel", async () => {
+    const user = userEvent.setup();
+    await renderRecorder();
+    await user.click(screen.getByRole("button", { name: /gravar novo atalho/i }));
+
+    vi.mocked(ipc.setRecordingShortcut).mockClear();
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(ipc.setRecordingShortcut).toHaveBeenCalledWith(false);
+  });
+
+  it("exits recording on window blur (defense-in-depth)", async () => {
+    const user = userEvent.setup();
+    await renderRecorder();
+    await user.click(screen.getByRole("button", { name: /gravar novo atalho/i }));
+
+    vi.mocked(ipc.setRecordingShortcut).mockClear();
+    fireEvent.blur(window);
+
+    expect(screen.queryByText(/pressione a combinação/i)).toBeNull();
+    expect(ipc.setRecordingShortcut).toHaveBeenCalledWith(false);
   });
 });

--- a/src/settings/__tests__/ShortcutSection.test.tsx
+++ b/src/settings/__tests__/ShortcutSection.test.tsx
@@ -3,6 +3,15 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nextProvider } from "react-i18next";
 import { createI18n } from "../../core/i18n";
+
+// ShortcutRecorder (used internally) calls ipc.setRecordingShortcut on
+// mount/cleanup. Stub it to avoid Tauri runtime calls during unit tests.
+vi.mock("../../core/ipc", () => ({
+  ipc: {
+    setRecordingShortcut: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 import { ShortcutSection } from "../ShortcutSection";
 
 async function renderSection(
@@ -11,6 +20,8 @@ async function renderSection(
   overrides: {
     searchShortcut?: string;
     onCaptureSearchShortcut?: (c: string) => Promise<void>;
+    settingsShortcut?: string;
+    onCaptureSettingsShortcut?: (c: string) => Promise<void>;
   } = {},
 ) {
   const i18n = await createI18n("pt-BR");
@@ -22,6 +33,13 @@ async function renderSection(
         searchShortcut={overrides.searchShortcut ?? "CommandOrControl+F"}
         onCaptureSearchShortcut={
           overrides.onCaptureSearchShortcut ??
+          (async () => {
+            /* noop */
+          })
+        }
+        settingsShortcut={overrides.settingsShortcut ?? "CommandOrControl+Shift+,"}
+        onCaptureSettingsShortcut={
+          overrides.onCaptureSettingsShortcut ??
           (async () => {
             /* noop */
           })
@@ -100,5 +118,36 @@ describe("ShortcutSection", () => {
       /alt\+?s/i.test(el.textContent ?? ""),
     );
     expect(hasSearch).toBe(true);
+  });
+
+  it("forwards the captured combo to onCaptureSettingsShortcut (settings shortcut)", async () => {
+    // Issue #66 — third recorder is the Settings shortcut.
+    const onCaptureSettingsShortcut = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    await renderSection(vi.fn(), undefined, { onCaptureSettingsShortcut });
+
+    const recordButtons = screen.getAllByRole("button", {
+      name: /gravar novo atalho/i,
+    });
+    expect(recordButtons).toHaveLength(3);
+    await user.click(recordButtons[2]);
+    fireEvent.keyDown(window, { key: "K", ctrlKey: true, shiftKey: true });
+
+    await waitFor(() =>
+      expect(onCaptureSettingsShortcut).toHaveBeenCalledWith(
+        "CommandOrControl+Shift+K",
+      ),
+    );
+  });
+
+  it("renders the settings shortcut current value in its recorder", async () => {
+    await renderSection(vi.fn(), undefined, {
+      settingsShortcut: "Ctrl+Alt+P",
+    });
+    const recorders = screen.getAllByText(/ctrl/i);
+    const hasSettings = recorders.some((el) =>
+      /alt\+?p/i.test(el.textContent ?? ""),
+    );
+    expect(hasSettings).toBe(true);
   });
 });

--- a/src/settings/useConfig.ts
+++ b/src/settings/useConfig.ts
@@ -36,6 +36,7 @@ export interface UseConfig {
   ) => Promise<Config>;
   reorderProfiles: (orderedIds: string[]) => Promise<Config>;
   setSearchShortcut: (combo: string) => Promise<Config>;
+  setSettingsShortcut: (combo: string) => Promise<Config>;
   setScriptTrusted: (
     profileId: string,
     tabId: string,
@@ -178,6 +179,12 @@ export function useConfig(): UseConfig {
     return next;
   }, []);
 
+  const setSettingsShortcut = useCallback(async (combo: string) => {
+    const next = await ipc.setSettingsShortcut(combo);
+    setConfig(next);
+    return next;
+  }, []);
+
   const setScriptTrusted = useCallback(
     async (
       profileId: string,
@@ -257,6 +264,7 @@ export function useConfig(): UseConfig {
     reorderTabs,
     reorderProfiles,
     setSearchShortcut,
+    setSettingsShortcut,
     setScriptTrusted,
     setProfileAllowScripts,
     setProfileThemeOverrides,


### PR DESCRIPTION
## Summary

- **#66** — Novo atalho global `interaction.settingsShortcut` (default `CommandOrControl+Shift+,`) que abre direto a janela de Settings, sem passar pelo donut/tray. Configurável na aba **Atalho** do Settings junto com os já existentes (donut + busca).
- **#80** — Suprime o handler global do donut/settings enquanto o usuário está gravando um atalho no `<ShortcutRecorder>`, evitando que a tecla pressionada abra a janela por cima do form de captura.

## Implementação

**Backend (Rust)**
- `Interaction.settings_shortcut: String` no schema + validação (`settings_shortcut_empty` / reuso de `shortcut::validate_combo`).
- `ActiveSettingsShortcut` em `AppState` + `register_settings_from_config` / `set_settings_from_config` com swap conflict-aware (registra novo antes de desregistrar antigo).
- Comando `set_settings_shortcut` com rollback duplo (memória + SO) em falha de `save_atomic`.
- `AppState.recording_shortcut: AtomicBool` + comando `set_recording_shortcut(bool)`. Ambos handlers globais (donut + settings) fazem early-return quando o flag está ligado.
- Registro do segundo handler global no `setup` do `lib.rs` (best-effort, log + segue em caso de conflito).

**Frontend**
- `<ShortcutSection>` ganhou 3ª entrada visual com `<ShortcutRecorder>` próprio + tradução pt-BR/en (`settings.shortcut.settingsSectionTitle` / `settingsHint`).
- `<ShortcutRecorder>` chama `ipc.setRecordingShortcut(true)` ao entrar em recording e `(false)` no cleanup do useEffect — cobre capture válido, Esc, unmount e blur defensivo.
- `useConfig.setSettingsShortcut` + IPC binding correspondente.

## Test plan

- [x] `cargo test --lib` — 431 passou (inclui testes novos: round-trip do campo, defaults para configs Plano-anteriores, validação de empty/garbage).
- [x] `npm test` — 531 passou (8 testes novos: 4 em `ShortcutRecorder.test.tsx` cobrindo recording flag + blur fallback; 2 em `ShortcutSection.test.tsx` cobrindo a 3ª entrada).
- [x] `npx tsc --noEmit` limpo.
- [x] `cargo fmt --check` limpo.
- [ ] Smoke manual (a fazer): configurar atalho de Settings, fechar Settings, pressionar — abre Settings. Gravar atalho do donut com `<ShortcutRecorder>` ativo + pressionar combo do donut — donut **não** aparece sobre Settings.

## Notas

- Compat: configs anteriores deserializam com `settings_shortcut = default_settings_shortcut()` graças ao `#[serde(default)]`.
- Clippy reportou `needless_return` em `src/launcher/mod.rs:310` — pré-existente em `main`, fora do escopo desta PR.

Closes #66
Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)