### PR TITLE
fix(shortcut): usar e.code físico no recorder pra ignorar dead keys (#81)

### DIFF
--- a/docs/qa-smoke.md
+++ b/docs/qa-smoke.md
@@ -22,6 +22,12 @@ Rodar este checklist antes de considerar o Plano 1 concluído. Repetir em cada S
 - [ ] **Tray → Abrir donut**: abre donut (no cursor atual).
 - [ ] **Tray → Sair**: app encerra limpamente. Atalho global deixa de responder.
 
+## Issue #81 — atalho com dead key (macOS Option+letra)
+
+- [ ] **macOS**: Settings → Atalho global → "Gravar novo atalho" → segurar `Option` e pressionar `C`. Combo gravada deve aparecer como `Alt+C` (não `…+Ç`) e ser registrada com sucesso (sem toast de erro do muda). Reabrir o app: atalho continua funcional.
+- [ ] **macOS**: repetir com Option+E (dead key acute), Option+N (tilde) e Option+Shift+8 — todas devem gravar a tecla física, sem composição diacrítica.
+- [ ] **Linux/Windows AltGr**: gravar AltGr+E (em layouts onde isso compõe `€` ou similar) deve resultar em `CommandOrControl+Alt+E` (tecla física), sem erro do parser.
+
 ## Issue #74 — autostart refresh em todo startup
 
 > Pré-requisito: build/install real (`npm run tauri build` + instalar bundle), não dev. Autostart entry só é registrado pelo plugin em release.

--- a/src/settings/__tests__/buildCombo.test.ts
+++ b/src/settings/__tests__/buildCombo.test.ts
@@ -125,4 +125,41 @@ describe("buildCombo", () => {
       error: null,
     });
   });
+
+  // Issue #81 — dead-key composition on Mac (Option+letter) and AltGr on
+  // Linux/Windows produce composed characters in `e.key` that the muda
+  // parser rejects. The fix is to prefer `e.code` (physical key) over
+  // `e.key` (composed character).
+  it("Mac Option+C: e.key='Ç' but e.code='KeyC' resolves to Alt+C", () => {
+    expect(
+      buildCombo(fake({ altKey: true, key: "Ç", code: "KeyC" })),
+    ).toMatchObject({ combo: "Alt+C", error: null });
+  });
+
+  it("Mac Option+E (dead key): e.key='Dead'/'´' with e.code='KeyE' → Alt+E", () => {
+    expect(
+      buildCombo(fake({ altKey: true, key: "Dead", code: "KeyE" })),
+    ).toMatchObject({ combo: "Alt+E", error: null });
+    expect(
+      buildCombo(fake({ altKey: true, key: "´", code: "KeyE" })),
+    ).toMatchObject({ combo: "Alt+E", error: null });
+  });
+
+  it("Mac Option+Shift+8: e.key='°' but e.code='Digit8' → Alt+Shift+8", () => {
+    expect(
+      buildCombo(fake({ altKey: true, shiftKey: true, key: "°", code: "Digit8" })),
+    ).toMatchObject({ combo: "Alt+Shift+8", error: null });
+  });
+
+  it("Linux AltGr+E: e.key='€' with e.code='KeyE' (ctrlKey+altKey) → CommandOrControl+Alt+E", () => {
+    expect(
+      buildCombo(fake({ ctrlKey: true, altKey: true, key: "€", code: "KeyE" })),
+    ).toMatchObject({ combo: "CommandOrControl+Alt+E", error: null });
+  });
+
+  it("regression: Ctrl+A with empty e.code still uses e.key path", () => {
+    expect(
+      buildCombo(fake({ ctrlKey: true, key: "a", code: "" })),
+    ).toMatchObject({ combo: "CommandOrControl+A", error: null });
+  });
 });

--- a/src/settings/buildCombo.ts
+++ b/src/settings/buildCombo.ts
@@ -26,6 +26,53 @@ const MODIFIER_KEYS = new Set([
   "ContextMenu",
 ]);
 
+const PASSTHROUGH_CODES = new Set([
+  "Space",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+  "Insert",
+  "Delete",
+  "Backspace",
+  "Minus",
+  "Equal",
+  "BracketLeft",
+  "BracketRight",
+  "Semicolon",
+  "Quote",
+  "Comma",
+  "Period",
+  "Slash",
+  "Backslash",
+  "Backquote",
+]);
+
+// Issue #81 — resolve a tecla física a partir de `KeyboardEvent.code`,
+// independente do layout/dead-key do SO. Sem isso, Option+C no Mac vira
+// "Ç" via composição diacrítica e o muda rejeita a string. O `code` é
+// estável por posição física (KeyC sempre é a tecla "C" no QWERTY).
+function physicalKeyFromCode(code: string | undefined): string | null {
+  if (!code) return null;
+  const letter = /^Key([A-Z])$/.exec(code);
+  if (letter) return letter[1];
+  const digit = /^Digit([0-9])$/.exec(code);
+  if (digit) return digit[1];
+  const numpad = /^Numpad([0-9])$/.exec(code);
+  if (numpad) return `Numpad${numpad[1]}`;
+  const fkey = /^F([1-9][0-9]?)$/.exec(code);
+  if (fkey) {
+    const n = parseInt(fkey[1], 10);
+    if (n >= 1 && n <= 24) return code;
+  }
+  if (code === "ArrowUp") return "Up";
+  if (code === "ArrowDown") return "Down";
+  if (code === "ArrowLeft") return "Left";
+  if (code === "ArrowRight") return "Right";
+  if (PASSTHROUGH_CODES.has(code)) return code;
+  return null;
+}
+
 /**
  * Converte `KeyboardEvent.key` em um nome aceito pelo Tauri global-shortcut.
  * Retorna `null` para teclas que não devem ser bindadas (modificadores
@@ -37,6 +84,13 @@ function normalizeKey(e: {
 }): { kind: "ok"; value: string } | { kind: "modifier" } | { kind: "reserved"; value: string } {
   const k = e.key;
   if (MODIFIER_KEYS.has(k)) return { kind: "modifier" };
+
+  // Issue #81 — preferir a key física pelo `code` quando disponível. Cobre
+  // o caso clássico Option+C no Mac (e.key="Ç" mas e.code="KeyC") e
+  // AltGr+E no Linux/Windows (e.key="€" mas e.code="KeyE").
+  const physical = physicalKeyFromCode(e.code);
+  if (physical !== null) return { kind: "ok", value: physical };
+
   if (RESERVED_KEYS.has(k)) return { kind: "reserved", value: k };
   if (k === " " || k === "Spacebar") return { kind: "ok", value: "Space" };
   if (k === "ArrowUp") return { kind: "ok", value: "Up" };


### PR DESCRIPTION
## Summary

- No macOS pt-BR, `Option+C` compõe `Ç` via dead key e o `muda` rejeita a string com `Couldn't recognize "Ç" as a valid key for hotkey…`. O recorder agora prefere `KeyboardEvent.code` (key física W3C) sobre `e.key` quando o code é reconhecido — resolve Option+letra no Mac e AltGr+letra no Linux/Windows sem regressão.
- Helper novo `physicalKeyFromCode` cobre `Key[A-Z]`, `Digit[0-9]`, `F1-24`, arrows, `Space`, navigation, `Numpad*` e símbolos comuns. Quando `e.code` é vazio ou não-mapeado (tests legados, layouts exóticos), cai no fallback antigo via `e.key`.
- Issue #72 (botão lateral do mouse) foi descartada após avaliação — fora do escopo.

## Test plan

- [x] `npm test` — 547/547 passando (5 cases novos em `buildCombo.test.ts`: Option+C, Option+E dead key, Option+Shift+8, AltGr+E, regressão Ctrl+A com `code: ""`).
- [x] `npx tsc --noEmit` — limpo.
- [ ] Smoke manual no macOS conforme `docs/qa-smoke.md` — gravar Option+C/E/N e Option+Shift+8, confirmar que combo final usa a tecla física e o atalho global registra sem erro do muda.
- [ ] Smoke manual no Linux com AltGr — gravar AltGr+E deve gerar `CommandOrControl+Alt+E` sem erro do parser.
- [ ] Smoke no Windows — verificar que combos comuns (`Ctrl+Shift+P` etc.) continuam idênticas.

Closes #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)