### PR TITLE
feat(settings): ajustes visuais — caret maior, "+ aba" no topo e switches (#86)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -351,7 +351,8 @@
       "groupNewHint": "Save the group first. Then reopen it from the list or click the donut's \"+\" to add tabs.",
       "focusIfOpen": {
         "label": "Focus if already open",
-        "hint": "Apps and tabs already open get focused; others open normally. URLs on macOS: Chrome, Safari, Edge, Arc, Brave, Vivaldi. Firefox is not supported (AppleScript limitation in Firefox).",
+        "hint": "Apps and tabs already open get focused; others open normally.",
+        "hintMac": "On macOS, focusing already-open URLs works with: Chrome, Safari, Edge, Arc, Brave, Vivaldi.\nIn other browsers, the URL may open as a new tab.",
         "firefoxWarning": "One or more URLs use Firefox as the browser. Firefox on macOS doesn't expose tabs via AppleScript, so those URLs will always open as a new tab. For tab focus, use Chrome, Safari, Edge, Arc, Brave, or Vivaldi."
       }
     },

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -351,7 +351,8 @@
       "groupNewHint": "Salve o grupo primeiro. Depois reabra-o pela lista ou clique no \"+\" do donut pra adicionar abas.",
       "focusIfOpen": {
         "label": "Focar se já estiver aberto",
-        "hint": "Apps e abas já abertos ganham foco; os demais abrem normalmente. URLs no macOS: Chrome, Safari, Edge, Arc, Brave, Vivaldi. Firefox não é suportado (limitação do AppleScript no Firefox).",
+        "hint": "Apps e abas já abertos ganham foco; os demais abrem normalmente.",
+        "hintMac": "No macOS, o foco em URLs já abertas funciona com: Chrome, Safari, Edge, Arc, Brave, Vivaldi.\nEm outros navegadores, a URL pode abrir como nova aba.",
         "firefoxWarning": "Uma ou mais URLs usam Firefox como navegador. O Firefox no macOS não expõe abas via AppleScript, então essas URLs abrirão sempre como nova aba. Para foco de aba, use Chrome, Safari, Edge, Arc, Brave ou Vivaldi."
       }
     },

--- a/src/settings/AppearanceSection.tsx
+++ b/src/settings/AppearanceSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { Theme } from "../core/types/Theme";
 import type { ThemeOverrides } from "../core/types/ThemeOverrides";
 import { ThemeCustomizer } from "./ThemeCustomizer";
+import { Switch } from "./Switch";
 
 export interface AppearanceSectionProps {
   theme: Theme;
@@ -81,11 +82,10 @@ export const AppearanceSection: React.FC<AppearanceSectionProps> = ({
           <label
             style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
           >
-            <input
-              type="checkbox"
+            <Switch
               data-testid="slice-gap-toggle"
               checked={sliceGapEnabled}
-              onChange={(e) => onSliceGapEnabledChange(e.target.checked)}
+              onChange={onSliceGapEnabledChange}
             />
             {t("settings.appearance.sliceGapLabel")}
           </label>

--- a/src/settings/GroupChildrenEditor.tsx
+++ b/src/settings/GroupChildrenEditor.tsx
@@ -31,6 +31,47 @@ export const GroupChildrenEditor: React.FC<GroupChildrenEditorProps> = ({
       style={{ display: "flex", flexDirection: "column", gap: 8 }}
     >
       <span>{t("settings.editor.groupChildrenLabel")}</span>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <button
+          type="button"
+          data-testid="add-child-leaf"
+          onClick={onAddChildLeaf}
+          style={{
+            background: "transparent",
+            color: "var(--fg)",
+            border: "1px solid var(--ghost-border)",
+            borderRadius: 4,
+            padding: "6px 12px",
+            cursor: "pointer",
+            font: "inherit",
+          }}
+        >
+          {t("settings.editor.addChildTab")}
+        </button>
+        {canAddSubgroup && onAddChildGroup && (
+          <button
+            type="button"
+            data-testid="add-child-group"
+            onClick={onAddChildGroup}
+            style={{
+              background: "transparent",
+              color: "var(--fg)",
+              border: "1px solid var(--ghost-border)",
+              borderRadius: 4,
+              padding: "6px 12px",
+              cursor: "pointer",
+              font: "inherit",
+            }}
+          >
+            {t("settings.editor.addChildGroup")}
+          </button>
+        )}
+        {!canAddSubgroup && (
+          <small style={{ color: "var(--muted)", alignSelf: "center" }}>
+            {t("settings.editor.maxDepthHint")}
+          </small>
+        )}
+      </div>
       {children.length === 0 ? (
         <small style={{ color: "var(--muted)" }}>
           {t("settings.editor.groupChildrenEmpty")}
@@ -84,47 +125,6 @@ export const GroupChildrenEditor: React.FC<GroupChildrenEditorProps> = ({
           ))}
         </ul>
       )}
-      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-        <button
-          type="button"
-          data-testid="add-child-leaf"
-          onClick={onAddChildLeaf}
-          style={{
-            background: "transparent",
-            color: "var(--fg)",
-            border: "1px solid var(--ghost-border)",
-            borderRadius: 4,
-            padding: "6px 12px",
-            cursor: "pointer",
-            font: "inherit",
-          }}
-        >
-          {t("settings.editor.addChildTab")}
-        </button>
-        {canAddSubgroup && onAddChildGroup && (
-          <button
-            type="button"
-            data-testid="add-child-group"
-            onClick={onAddChildGroup}
-            style={{
-              background: "transparent",
-              color: "var(--fg)",
-              border: "1px solid var(--ghost-border)",
-              borderRadius: 4,
-              padding: "6px 12px",
-              cursor: "pointer",
-              font: "inherit",
-            }}
-          >
-            {t("settings.editor.addChildGroup")}
-          </button>
-        )}
-        {!canAddSubgroup && (
-          <small style={{ color: "var(--muted)", alignSelf: "center" }}>
-            {t("settings.editor.maxDepthHint")}
-          </small>
-        )}
-      </div>
     </div>
   );
 };

--- a/src/settings/ItemListEditor.tsx
+++ b/src/settings/ItemListEditor.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { dialog, ipc } from "../core/ipc";
 import { AppPicker } from "./AppPicker";
 import { ScriptHelpModal } from "./ScriptHelpModal";
+import { Switch } from "./Switch";
 import type { InstalledApp } from "../core/types/InstalledApp";
 import type { MonitorInfo } from "../core/types/MonitorInfo";
 
@@ -457,11 +458,10 @@ export const ItemListEditor: React.FC<ItemListEditorProps> = ({
                 }}
                 title={t("settings.editor.incognitoHint")}
               >
-                <input
-                  type="checkbox"
+                <Switch
                   data-testid={`item-incognito-${i}`}
                   checked={!!it.incognito}
-                  onChange={(e) => updateAt(i, { incognito: e.target.checked })}
+                  onChange={(next) => updateAt(i, { incognito: next })}
                 />
                 {t("settings.editor.incognitoLabel")}
               </label>
@@ -489,11 +489,10 @@ export const ItemListEditor: React.FC<ItemListEditorProps> = ({
               }}
             >
               <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
-                <input
-                  type="checkbox"
+                <Switch
                   data-testid={`item-script-trusted-${i}`}
                   checked={!!it.trusted}
-                  onChange={(e) => updateAt(i, { trusted: e.target.checked })}
+                  onChange={(next) => updateAt(i, { trusted: next })}
                 />
                 {t("settings.editor.scriptTrustedLabel")}
               </label>

--- a/src/settings/Switch.tsx
+++ b/src/settings/Switch.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+
+export interface SwitchProps {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  disabled?: boolean;
+  id?: string;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  "data-testid"?: string;
+}
+
+const TRACK_WIDTH = 36;
+const TRACK_HEIGHT = 20;
+const THUMB_SIZE = 16;
+const THUMB_MARGIN = (TRACK_HEIGHT - THUMB_SIZE) / 2;
+const THUMB_TRAVEL = TRACK_WIDTH - THUMB_SIZE - THUMB_MARGIN * 2;
+
+export const Switch: React.FC<SwitchProps> = ({
+  checked,
+  onChange,
+  disabled,
+  id,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
+  "data-testid": testId,
+}) => {
+  const handleClick = () => {
+    if (disabled) return;
+    onChange(!checked);
+  };
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (disabled) return;
+    if (e.key === " " || e.key === "Enter") {
+      e.preventDefault();
+      onChange(!checked);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      id={id}
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      data-testid={testId}
+      disabled={disabled}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      style={{
+        position: "relative",
+        width: TRACK_WIDTH,
+        height: TRACK_HEIGHT,
+        flexShrink: 0,
+        padding: 0,
+        border: `1px solid ${checked ? "var(--selected-border)" : "var(--input-border)"}`,
+        borderRadius: TRACK_HEIGHT,
+        background: checked ? "var(--accent-bg)" : "var(--input-bg)",
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+        transition: "background 120ms ease, border-color 120ms ease",
+        display: "inline-block",
+        verticalAlign: "middle",
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          top: THUMB_MARGIN,
+          left: THUMB_MARGIN,
+          width: THUMB_SIZE,
+          height: THUMB_SIZE,
+          borderRadius: "50%",
+          background: checked ? "var(--accent-fg)" : "var(--muted)",
+          transform: `translateX(${checked ? THUMB_TRAVEL : 0}px)`,
+          transition: "transform 120ms ease, background 120ms ease",
+          boxShadow: "0 1px 2px rgba(0, 0, 0, 0.3)",
+        }}
+      />
+    </button>
+  );
+};

--- a/src/settings/SystemSection.tsx
+++ b/src/settings/SystemSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { Language } from "../core/types/Language";
 import type { SpawnPosition } from "../core/types/SpawnPosition";
 import { groupStyle, legendStyle } from "./fieldsetStyles";
+import { Switch } from "./Switch";
 
 export interface SystemSectionProps {
   language: Language;
@@ -104,11 +105,10 @@ export const SystemSection: React.FC<SystemSectionProps> = ({
           <label
             style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
           >
-            <input
-              type="checkbox"
+            <Switch
               data-testid="autostart-toggle"
               checked={autostart}
-              onChange={(e) => onAutostartChange(e.target.checked)}
+              onChange={onAutostartChange}
             />
             {t("settings.system.autostart")}
           </label>
@@ -164,11 +164,10 @@ export const SystemSection: React.FC<SystemSectionProps> = ({
               <label
                 style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
               >
-                <input
-                  type="checkbox"
+                <Switch
                   data-testid="quick-mode-toggle"
                   checked={quickMode}
-                  onChange={(e) => onQuickModeChange(e.target.checked)}
+                  onChange={onQuickModeChange}
                 />
                 {t("settings.system.quickModeLabel")}
               </label>
@@ -191,11 +190,10 @@ export const SystemSection: React.FC<SystemSectionProps> = ({
               <label
                 style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
               >
-                <input
-                  type="checkbox"
+                <Switch
                   data-testid="allow-scripts-toggle"
                   checked={allowScripts}
-                  onChange={(e) => onAllowScriptsChange(e.target.checked)}
+                  onChange={onAllowScriptsChange}
                 />
                 {t("settings.system.allowScriptsLabel")}
               </label>
@@ -210,11 +208,10 @@ export const SystemSection: React.FC<SystemSectionProps> = ({
               <label
                 style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
               >
-                <input
-                  type="checkbox"
+                <Switch
                   data-testid="script-history-toggle"
                   checked={scriptHistoryEnabled}
-                  onChange={(e) => onScriptHistoryEnabledChange(e.target.checked)}
+                  onChange={onScriptHistoryEnabledChange}
                 />
                 {t("settings.system.scriptHistoryLabel")}
               </label>

--- a/src/settings/TabEditor.tsx
+++ b/src/settings/TabEditor.tsx
@@ -6,6 +6,7 @@ import { translateAppError } from "../core/errors";
 import { graphemeCount } from "./textUtils";
 import { IconPicker } from "./IconPicker";
 import { IconField } from "./IconField";
+import { Switch } from "./Switch";
 import type { Tab } from "../core/types/Tab";
 import type { Item } from "../core/types/Item";
 import type { OpenMode } from "../core/types/OpenMode";
@@ -13,6 +14,11 @@ import type { TabKind as SchemaTabKind } from "../core/types/TabKind";
 
 const LUCIDE_PREFIX = "lucide:";
 const isLucideToken = (s: string) => s.startsWith(LUCIDE_PREFIX);
+
+const isMacPlatform = (): boolean => {
+  if (typeof navigator === "undefined") return false;
+  return /Mac/i.test(navigator.platform);
+};
 
 /** Plano 16 / Issue #39: alinhado com `MAX_TAB_DEPTH` em `validate.rs`.
  *  Reduzido de 3 pra 2 pra encolher a janela do donut. */
@@ -264,8 +270,9 @@ export const TabEditor: React.FC<TabEditorProps> = ({
       // leaf nunca persiste children; group preserva os existentes ou
       // inicia vazio (user adiciona depois via "+ Adicionar aba").
       children: state.kind === "group" ? initial?.children ?? [] : [],
-      // Plano 24 — toggle por aba lido pelo launcher em runtime.
-      focusIfOpen: state.focusIfOpen,
+      // Plano 24 — toggle por aba lido pelo launcher em runtime. Grupos
+      // não usam essa lógica (sem items), então sempre persistimos `false`.
+      focusIfOpen: state.kind === "leaf" ? state.focusIfOpen : false,
     };
 
     setSaving(true);
@@ -362,22 +369,28 @@ export const TabEditor: React.FC<TabEditorProps> = ({
         onSelect={(icon) => setState((s) => ({ ...s, icon }))}
       />
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-        <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
-          <input
-            type="checkbox"
-            data-testid="tab-focus-if-open"
-            checked={state.focusIfOpen}
-            onChange={(e) => setState({ ...state, focusIfOpen: e.target.checked })}
-          />
-          <span>{t("settings.editor.focusIfOpen.label")}</span>
-        </label>
-        <small style={{ color: "var(--muted)" }}>
-          {t("settings.editor.focusIfOpen.hint")}
-        </small>
-        {state.focusIfOpen &&
-          state.kind === "leaf" &&
-          hasFirefoxUrlItem(state.items) && (
+      {state.kind === "leaf" && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
+            <Switch
+              data-testid="tab-focus-if-open"
+              checked={state.focusIfOpen}
+              onChange={(next) => setState({ ...state, focusIfOpen: next })}
+            />
+            <span>{t("settings.editor.focusIfOpen.label")}</span>
+          </label>
+          <small style={{ color: "var(--muted)" }}>
+            {t("settings.editor.focusIfOpen.hint")}
+          </small>
+          {isMacPlatform() && (
+            <small
+              data-testid="tab-focus-mac-hint"
+              style={{ color: "var(--muted)", whiteSpace: "pre-line" }}
+            >
+              {t("settings.editor.focusIfOpen.hintMac")}
+            </small>
+          )}
+          {state.focusIfOpen && hasFirefoxUrlItem(state.items) && (
             <div
               role="alert"
               data-testid="tab-focus-firefox-warning"
@@ -394,7 +407,8 @@ export const TabEditor: React.FC<TabEditorProps> = ({
               {t("settings.editor.focusIfOpen.firefoxWarning")}
             </div>
           )}
-      </div>
+        </div>
+      )}
 
       {mode === "new" && (
         <fieldset

--- a/src/settings/TabList.tsx
+++ b/src/settings/TabList.tsx
@@ -92,20 +92,21 @@ const NodeRow: React.FC<NodeRowProps> = ({
               toggle(tab.id);
             }}
             style={{
-              width: 18,
+              width: 22,
               height: 22,
               background: "transparent",
               border: 0,
               color: "var(--muted)",
               cursor: "pointer",
-              fontSize: 11,
+              fontSize: 16,
               padding: 0,
+              lineHeight: 1,
             }}
           >
             {isOpen ? "▾" : "▸"}
           </button>
         ) : (
-          <span style={{ width: 18 }} aria-hidden="true" />
+          <span style={{ width: 22 }} aria-hidden="true" />
         )}
         <button
           type="button"
@@ -228,28 +229,12 @@ const GroupBody: React.FC<GroupBodyProps> = ({
         gap: 4,
       }}
     >
-      {ordered.map((child) => (
-        <NodeRow
-          key={child.id}
-          tab={child}
-          parentPath={myPath}
-          depth={myDepth}
-          maxDepth={maxDepth}
-          selectedId={selectedId}
-          expanded={expanded}
-          toggle={toggle}
-          onSelect={onSelect}
-          onAdd={onAdd}
-          onReorder={onReorder}
-          dragProps={getItemProps(child.id)}
-        />
-      ))}
       <li
         style={{
           display: "flex",
           gap: 6,
           paddingLeft: indentPx,
-          marginTop: 4,
+          marginBottom: 4,
         }}
       >
         <button
@@ -287,6 +272,22 @@ const GroupBody: React.FC<GroupBodyProps> = ({
           </button>
         )}
       </li>
+      {ordered.map((child) => (
+        <NodeRow
+          key={child.id}
+          tab={child}
+          parentPath={myPath}
+          depth={myDepth}
+          maxDepth={maxDepth}
+          selectedId={selectedId}
+          expanded={expanded}
+          toggle={toggle}
+          onSelect={onSelect}
+          onAdd={onAdd}
+          onReorder={onReorder}
+          dragProps={getItemProps(child.id)}
+        />
+      ))}
     </ul>
   );
 };

--- a/src/settings/UpdateCard.tsx
+++ b/src/settings/UpdateCard.tsx
@@ -8,6 +8,7 @@ import {
 } from "../core/ipc";
 import type { UpdateSummary } from "../core/types/UpdateSummary";
 import { translateAppError } from "../core/errors";
+import { Switch } from "./Switch";
 
 export interface UpdateCardProps {
   autoCheckUpdates: boolean;
@@ -107,11 +108,10 @@ export const UpdateCard: React.FC<UpdateCardProps> = ({
       <label
         style={{ display: "flex", gap: 6, alignItems: "center", padding: 4 }}
       >
-        <input
-          type="checkbox"
+        <Switch
           data-testid="auto-check-updates-toggle"
           checked={autoCheckUpdates}
-          onChange={(e) => onAutoCheckUpdatesChange(e.target.checked)}
+          onChange={onAutoCheckUpdatesChange}
         />
         {t("settings.system.update.autoCheckLabel")}
       </label>

--- a/src/settings/__tests__/AboutSection.test.tsx
+++ b/src/settings/__tests__/AboutSection.test.tsx
@@ -110,10 +110,8 @@ describe("AboutSection", () => {
     await waitFor(() => {
       expect(screen.getByTestId("update-card")).toBeTruthy();
     });
-    const cb = screen.getByTestId(
-      "auto-check-updates-toggle",
-    ) as HTMLInputElement;
-    expect(cb.checked).toBe(true);
+    const cb = screen.getByTestId("auto-check-updates-toggle");
+    expect(cb.getAttribute("aria-checked")).toBe("true");
   });
 
   it("propagates auto-check toggle changes to the callback", async () => {

--- a/src/settings/__tests__/ItemListEditor.test.tsx
+++ b/src/settings/__tests__/ItemListEditor.test.tsx
@@ -417,9 +417,9 @@ describe("ItemListEditor", () => {
     // o checkbox e impedisse o user de marcar trust antes de salvar. Agora
     // renderiza sempre que kind === "script", tratando undefined como unchecked.
     await renderEditor([{ kind: "script", value: "ls", openWith: "" }]);
-    const cb = screen.getByTestId("item-script-trusted-0") as HTMLInputElement;
+    const cb = screen.getByTestId("item-script-trusted-0");
     expect(cb).toBeTruthy();
-    expect(cb.checked).toBe(false);
+    expect(cb.getAttribute("aria-checked")).toBe("false");
   });
 
   it("app row shows the app picker button; selecting an app fills the value", async () => {

--- a/src/settings/__tests__/SystemSection.test.tsx
+++ b/src/settings/__tests__/SystemSection.test.tsx
@@ -52,8 +52,8 @@ describe("SystemSection", () => {
 
   it("autostart checkbox reflects the current value", async () => {
     await renderSection({ autostart: true });
-    const cb = screen.getByTestId("autostart-toggle") as HTMLInputElement;
-    expect(cb.checked).toBe(true);
+    const cb = screen.getByTestId("autostart-toggle");
+    expect(cb.getAttribute("aria-checked")).toBe("true");
   });
 
   it("calls onAutostartChange when the checkbox is toggled", async () => {
@@ -92,8 +92,8 @@ describe("SystemSection", () => {
       scriptHistoryEnabled: true,
       onScriptHistoryEnabledChange: vi.fn(),
     });
-    const cb = screen.getByTestId("script-history-toggle") as HTMLInputElement;
-    expect(cb.checked).toBe(true);
+    const cb = screen.getByTestId("script-history-toggle");
+    expect(cb.getAttribute("aria-checked")).toBe("true");
   });
 
   it("Issue #54 (rev) — toggling the script-history checkbox calls the handler", async () => {
@@ -113,8 +113,8 @@ describe("SystemSection", () => {
 
   it("Issue #71 — quick-mode toggle reflects current value", async () => {
     await renderSection({ quickMode: true, onQuickModeChange: vi.fn() });
-    const cb = screen.getByTestId("quick-mode-toggle") as HTMLInputElement;
-    expect(cb.checked).toBe(true);
+    const cb = screen.getByTestId("quick-mode-toggle");
+    expect(cb.getAttribute("aria-checked")).toBe("true");
   });
 
   it("Issue #71 — toggling the quick-mode checkbox calls the handler", async () => {

--- a/src/settings/__tests__/TabEditor.test.tsx
+++ b/src/settings/__tests__/TabEditor.test.tsx
@@ -434,8 +434,8 @@ describe("TabEditor", () => {
       initial: tabWithTrustedScript,
     });
     expect(
-      (screen.getByTestId("item-script-trusted-0") as HTMLInputElement).checked,
-    ).toBe(true);
+      screen.getByTestId("item-script-trusted-0").getAttribute("aria-checked"),
+    ).toBe("true");
     await user.click(screen.getByRole("button", { name: /^salvar$/i }));
     const payload = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as Tab;
     expect(payload.items).toEqual([
@@ -506,8 +506,8 @@ describe("TabEditor", () => {
   it("defaults focus_if_open to false in new tab and submits it", async () => {
     const user = userEvent.setup();
     const { props } = await renderEditor();
-    const checkbox = screen.getByTestId("tab-focus-if-open") as HTMLInputElement;
-    expect(checkbox.checked).toBe(false);
+    const checkbox = screen.getByTestId("tab-focus-if-open");
+    expect(checkbox.getAttribute("aria-checked")).toBe("false");
     await user.type(screen.getByLabelText(/nome/i), "Foo");
     await user.type(screen.getByLabelText(/url 1/i), "https://ok.test");
     await user.click(screen.getByRole("button", { name: /^salvar$/i }));
@@ -518,10 +518,10 @@ describe("TabEditor", () => {
   it("toggling focus_if_open propagates to the save payload", async () => {
     const user = userEvent.setup();
     const { props } = await renderEditor({ mode: "edit", initial: existing });
-    const checkbox = screen.getByTestId("tab-focus-if-open") as HTMLInputElement;
-    expect(checkbox.checked).toBe(false);
+    const checkbox = screen.getByTestId("tab-focus-if-open");
+    expect(checkbox.getAttribute("aria-checked")).toBe("false");
     await user.click(checkbox);
-    expect(checkbox.checked).toBe(true);
+    expect(checkbox.getAttribute("aria-checked")).toBe("true");
     await user.click(screen.getByRole("button", { name: /^salvar$/i }));
     const payload = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as Tab;
     expect(payload.focusIfOpen).toBe(true);
@@ -530,8 +530,8 @@ describe("TabEditor", () => {
   it("hydrates focus_if_open from initial tab when editing", async () => {
     const focused: Tab = { ...existing, focusIfOpen: true };
     await renderEditor({ mode: "edit", initial: focused });
-    const checkbox = screen.getByTestId("tab-focus-if-open") as HTMLInputElement;
-    expect(checkbox.checked).toBe(true);
+    const checkbox = screen.getByTestId("tab-focus-if-open");
+    expect(checkbox.getAttribute("aria-checked")).toBe("true");
   });
 
   it("shows Firefox warning when focus_if_open=true and a URL uses openWith=Firefox", async () => {

--- a/src/settings/__tests__/UpdateCard.test.tsx
+++ b/src/settings/__tests__/UpdateCard.test.tsx
@@ -173,10 +173,8 @@ describe("UpdateCard", () => {
     vi.mocked(ipc.getPendingUpdate).mockResolvedValue(null);
     const { onAutoChange } = await renderCard(true);
     const user = userEvent.setup();
-    const cb = screen.getByTestId(
-      "auto-check-updates-toggle",
-    ) as HTMLInputElement;
-    expect(cb.checked).toBe(true);
+    const cb = screen.getByTestId("auto-check-updates-toggle");
+    expect(cb.getAttribute("aria-checked")).toBe("true");
     await user.click(cb);
     expect(onAutoChange).toHaveBeenCalledWith(false);
   });


### PR DESCRIPTION
Resolve #86.

## Summary

- **Caret de grupo maior** em `TabList`: a seta `▸/▾` que expande/colapsa um grupo na árvore de Abas vai de `fontSize: 11` → `16` (width 18 → 22) — bem mais legível.
- **"+ Adicionar aba" no topo** dos filhos de um grupo, tanto na árvore de `TabList` quanto no `<GroupChildrenEditor>` do editor de aba. A ação mais frequente deixa de ficar escondida no fim da lista.
- **Switches em vez de checkboxes** — novo componente `<Switch>` (`role="switch"`, track + thumb com transição CSS) substitui 9 toggles em `AppearanceSection`, `SystemSection` (×4), `ItemListEditor` (×2), `TabEditor` e `UpdateCard`. O checkbox do `ScriptConfirmModal` foi mantido a pedido (superfície de segurança).
- **Foco escondido para grupos**: o toggle "Focar se já estiver aberto" só renderiza quando a aba em edição é `kind === "leaf"`. Grupos não usam essa lógica (não têm items), então save persiste `focusIfOpen: false`.
- **Hint do macOS reformulado**: o texto antigo misturava a limitação do recurso de foco com a abertura de URL e podia sugerir que URLs em outros navegadores não eram suportadas. Agora a hint geral é neutra; uma `hintMac` adicional, renderizada apenas em máquinas Mac (`/Mac/i.test(navigator.platform)`), explica que **o foco** em URLs já abertas só funciona em Chrome/Safari/Edge/Arc/Brave/Vivaldi e que em outros navegadores a URL pode abrir como nova aba.

## Test plan

- [x] `npx tsc --noEmit` limpo
- [x] `npm test` — 547/547 passando (testes de toggles agora verificam `aria-checked` via `getAttribute`)
- [ ] Smoke manual: abrir Settings → seção Abas, expandir um grupo (caret nítido), verificar "+ Adicionar aba" acima dos filhos, alternar todos os switches (autostart, modo rápido, allow-scripts, script-history, slice-gap, focus-if-open, item-incognito, item-script-trusted, auto-check-updates) e confirmar persistência via `config-changed`
- [ ] Editar um grupo: toggle de foco deve estar ausente; salvar e reabrir → `focusIfOpen` permanece `false`
- [ ] Em uma Mac, abrir editor de aba leaf: hint geral + hint Mac (duas linhas) visíveis; em Windows/Linux só a hint geral

🤖 Generated with [Claude Code](https://claude.com/claude-code)