### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "donuttabs",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "donuttabs"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "donuttabs"
-version = "1.1.0"
+version = "1.2.0"
 description = "DonutTabs — radial tab launcher triggered by a global shortcut"
 authors = ["Yuri Hemmel <yuri.modolin@helppi.com.br>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DonutTabs",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "identifier": "com.donuttabs.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Release v1.2.0 — bump de versão em `tauri.conf.json`, `Cargo.toml`, `Cargo.lock` e `package.json`.

## Mudanças incluídas (desde v1.1.0)

- feat(settings): Setup Wizard com tour das funcionalidades (#88)
- feat(settings): ajustes visuais — caret maior, "+ aba" no topo, switches (#87)
- fix(shortcut): recorder usa e.code físico, ignora dead keys (#85)
- feat(launcher): foco por aba em apps/URLs já abertos (#83)
- feat(shortcut): atalho global para abrir Settings (#84)
- feat(donut): modo rápido + hover-to-expand de grupos (#82)
- fix(settings): editor retargeta para o perfil ativo + badges (#79)
- feat(settings): aba "Sobre" (#78)
- fix(autostart): refresca entry do SO em todo startup (#75)

## Test plan

- [ ] CI verde (frontend, lint, test-linux, test-macos, test-windows)
- [ ] Após merge, criar tag annotated `v1.2.0` na main com release notes
- [ ] Workflow `release.yml` produz bundles + `latest.json` válido

🤖 Generated with [Claude Code](https://claude.com/claude-code)