### PR TITLE
ci(release): propagar tag annotation pro tauri-action (fix #95, #94)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_id: ${{ steps.create-release.outputs.result }}
+      release_body: ${{ steps.notes.outputs.body }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -98,6 +99,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
+          releaseBody: ${{ needs.create-release.outputs.release_body }}
           includeUpdaterJson: true
 
   publish-release:


### PR DESCRIPTION
## Summary

- Expõe `steps.notes.outputs.body` como output `release_body` do job `create-release` e passa via `releaseBody:` pro `tauri-action@v0` no job `build-tauri`.
- Corrige #95: o action agora grava o changelog da tag annotation em `latest.json.notes` (antes saía `null`, deixando o `<UpdateCard>` dos apps instalados sem contexto do que mudou).
- Como efeito colateral também corrige #94: o body do GitHub Release passa a refletir a tag annotation em vez do commit message do squash.

## Test plan

- [ ] No próximo release (`v*` tag), validar: \`curl -sL https://github.com/YuriHemmel/DonutTabs/releases/latest/download/latest.json | jq -r '.notes'\` deve imprimir o changelog.
- [ ] Conferir na UI do GitHub que o body do release reflete a tag annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)