### PR TITLE
fix(ci): preservar body do release pós tauri-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,12 +111,14 @@ jobs:
         uses: actions/github-script@v7
         env:
           RELEASE_ID: ${{ needs.create-release.outputs.release_id }}
+          RELEASE_BODY: ${{ needs.create-release.outputs.release_body }}
         with:
           script: |
             await github.rest.repos.updateRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: Number(process.env.RELEASE_ID),
+              body: process.env.RELEASE_BODY,
               draft: false,
               prerelease: false,
             })


### PR DESCRIPTION
## Summary

- O `tauri-apps/tauri-action@v0` sobrescreve o body do release ao subir os bundles via `releaseId`, derrubando as notas extraídas da tag annotation no job `create-release`.
- Re-seta o body no step final `Flip release from draft to published` via `updateRelease`, garantindo que o release publicado mostre o conteúdo da tag annotation independente do que o `tauri-action` fizer.
- Opção 2 da issue (mais defensiva — não depende do `tauri-action` aceitar um input específico).

Fixes #94. Provavelmente resolve #95 de carona, já que o `latest.json` consumido pelo `<UpdateCard>` é gerado a partir do release final — a validar no smoke.

## Test plan

- [ ] Inspeção visual do diff (3 linhas adicionadas em `.github/workflows/release.yml`).
- [ ] Smoke: na próxima tag (`v1.2.1` / `v1.3.0`), confirmar na UI do GitHub Releases que o body publicado é a tag annotation, não o commit message do squash.
- [ ] Verificar se `notes` no `latest.json` post-publish também reflete a tag annotation (fechar #95 ou abrir fix separado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)