### PR TITLE
fix(donut): gap perpendicular constante entre slices (#89)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "donuttabs",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "donuttabs",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/src/donut/Donut.tsx
+++ b/src/donut/Donut.tsx
@@ -9,12 +9,12 @@ import { PaginationDots } from "./PaginationDots";
 import { HoverHoldOverlay } from "./HoverHoldOverlay";
 import { ProfileSwitcher } from "./ProfileSwitcher";
 import {
-  OUTER_SLICE_ANGULAR_GAP_RAD,
+  OUTER_SLICE_GAP_PX,
   pointToRingIndex,
   pointToSliceIndex,
   ringDims,
   ringHitBounds,
-  slicePaintRange,
+  slicePaintAngles,
   type RingDims,
 } from "./geometry";
 import { paginate } from "./pagination";
@@ -78,6 +78,11 @@ interface TabSliceProps {
   outerR: number;
   startAngle: number;
   endAngle: number;
+  /** Issue #89 — corners do path; quando omitidos, herdam start/end. */
+  innerStartAngle?: number;
+  innerEndAngle?: number;
+  outerStartAngle?: number;
+  outerEndAngle?: number;
   highlighted: boolean;
   onClick: () => void;
   onContextMenu?: (e: React.MouseEvent<SVGGElement>) => void;
@@ -582,12 +587,14 @@ export const Donut: React.FC<DonutProps> = ({
             return (
               <g key={ringKeyStr}>
                 {current.tabs.map((tab, sliceIdx) => {
-                  // Plano 23 — todos os rings (incluindo root) ganham
-                  // respiro angular entre vizinhos.
-                  const { start, end } = slicePaintRange(
+                  // Issue #89 — todos os rings (incluindo root) ganham
+                  // respiro perpendicular constante entre vizinhos.
+                  const angles = slicePaintAngles(
                     sliceIdx,
                     sliceCount,
-                    sliceGapEnabled ? OUTER_SLICE_ANGULAR_GAP_RAD : 0,
+                    sliceGapEnabled ? OUTER_SLICE_GAP_PX : 0,
+                    dims.innerR,
+                    dims.outerR,
                   );
                   const isHighlighted =
                     hovered !== null &&
@@ -601,8 +608,12 @@ export const Donut: React.FC<DonutProps> = ({
                       cy={cy}
                       innerR={dims.innerR}
                       outerR={dims.outerR}
-                      startAngle={start}
-                      endAngle={end}
+                      startAngle={angles.outerStart}
+                      endAngle={angles.outerEnd}
+                      innerStartAngle={angles.innerStart}
+                      innerEndAngle={angles.innerEnd}
+                      outerStartAngle={angles.outerStart}
+                      outerEndAngle={angles.outerEnd}
                       highlighted={isHighlighted}
                       onClick={() => {
                         const phase = hoverHold.state.phase;
@@ -640,10 +651,12 @@ export const Donut: React.FC<DonutProps> = ({
                 })}
                 {current.hasPlus &&
                   (() => {
-                    const { start, end } = slicePaintRange(
+                    const angles = slicePaintAngles(
                       plusIdx,
                       sliceCount,
-                      sliceGapEnabled ? OUTER_SLICE_ANGULAR_GAP_RAD : 0,
+                      sliceGapEnabled ? OUTER_SLICE_GAP_PX : 0,
+                      dims.innerR,
+                      dims.outerR,
                     );
                     return (
                       <Slice
@@ -652,8 +665,12 @@ export const Donut: React.FC<DonutProps> = ({
                         cy={cy}
                         innerR={dims.innerR}
                         outerR={dims.outerR}
-                        startAngle={start}
-                        endAngle={end}
+                        startAngle={angles.outerStart}
+                        endAngle={angles.outerEnd}
+                        innerStartAngle={angles.innerStart}
+                        innerEndAngle={angles.innerEnd}
+                        outerStartAngle={angles.outerStart}
+                        outerEndAngle={angles.outerEnd}
                         icon="+"
                         highlighted={
                           hovered !== null &&
@@ -671,12 +688,14 @@ export const Donut: React.FC<DonutProps> = ({
             active &&
             activeRingDims &&
             (() => {
-              // Plano 23 — overlay casa a pintura do slice. Todos os rings
-              // usam o mesmo gap angular.
-              const { start, end } = slicePaintRange(
+              // Issue #89 — overlay casa a pintura do slice. Mesmo gap
+              // perpendicular constante usado nas slices abaixo.
+              const angles = slicePaintAngles(
                 active.slice,
                 activeRingSliceCount,
-                sliceGapEnabled ? OUTER_SLICE_ANGULAR_GAP_RAD : 0,
+                sliceGapEnabled ? OUTER_SLICE_GAP_PX : 0,
+                activeRingDims.innerR,
+                activeRingDims.outerR,
               );
               const parentPath = parentPathForRing(
                 visibleRings[active.ring]?.depth ?? 0,
@@ -687,8 +706,12 @@ export const Donut: React.FC<DonutProps> = ({
                   cy={cy}
                   innerR={activeRingDims.innerR}
                   outerR={activeRingDims.outerR}
-                  startAngle={start}
-                  endAngle={end}
+                  startAngle={angles.outerStart}
+                  endAngle={angles.outerEnd}
+                  innerStartAngle={angles.innerStart}
+                  innerEndAngle={angles.innerEnd}
+                  outerStartAngle={angles.outerStart}
+                  outerEndAngle={angles.outerEnd}
                   state={hoverHold.state}
                   onEdit={() => {
                     hoverHold.cancel();

--- a/src/donut/HoverHoldOverlay.tsx
+++ b/src/donut/HoverHoldOverlay.tsx
@@ -10,6 +10,12 @@ export interface HoverHoldOverlayProps {
   outerR: number;
   startAngle: number;
   endAngle: number;
+  /** Issue #89 — quando definidos, sobrescrevem os corners do path para
+   *  casar o overlay com o trim perpendicular do slice por baixo. */
+  innerStartAngle?: number;
+  innerEndAngle?: number;
+  outerStartAngle?: number;
+  outerEndAngle?: number;
   state: HoverHoldPhase;
   onEdit: () => void;
   onRequestDelete: () => void;
@@ -24,6 +30,10 @@ export const HoverHoldOverlay: React.FC<HoverHoldOverlayProps> = ({
   outerR,
   startAngle,
   endAngle,
+  innerStartAngle,
+  innerEndAngle,
+  outerStartAngle,
+  outerEndAngle,
   state,
   onEdit,
   onRequestDelete,
@@ -35,6 +45,12 @@ export const HoverHoldOverlay: React.FC<HoverHoldOverlayProps> = ({
 
   const mid = (startAngle + endAngle) / 2;
   const labelR = (innerR + outerR) / 2;
+  const iStart = innerStartAngle ?? startAngle;
+  const iEnd = innerEndAngle ?? endAngle;
+  const oStart = outerStartAngle ?? startAngle;
+  const oEnd = outerEndAngle ?? endAngle;
+  const innerMid = (iStart + iEnd) / 2;
+  const outerMid = (oStart + oEnd) / 2;
 
   if (state.phase === "holding") {
     // Preenchimento radial: arco com mesmo ângulo, raio externo cresce até outerR.
@@ -46,6 +62,10 @@ export const HoverHoldOverlay: React.FC<HoverHoldOverlayProps> = ({
       outerR: filledOuter,
       startAngle,
       endAngle,
+      innerStartAngle: iStart,
+      innerEndAngle: iEnd,
+      outerStartAngle: oStart,
+      outerEndAngle: oEnd,
     });
     return (
       <g data-testid="hover-hold-fill" pointerEvents="none">
@@ -55,6 +75,8 @@ export const HoverHoldOverlay: React.FC<HoverHoldOverlayProps> = ({
   }
 
   // actionable / confirming → divisão metade-metade, esquerda ✏️ direita 🗑️.
+  // Issue #89 — split midpoint usa innerMid/outerMid (sem gap no meio, é
+  // borda interna do mesmo slice).
   const editPath = arcPath({
     cx,
     cy,
@@ -62,6 +84,10 @@ export const HoverHoldOverlay: React.FC<HoverHoldOverlayProps> = ({
     outerR,
     startAngle,
     endAngle: mid,
+    innerStartAngle: iStart,
+    innerEndAngle: innerMid,
+    outerStartAngle: oStart,
+    outerEndAngle: outerMid,
   });
   const deletePath = arcPath({
     cx,
@@ -70,6 +96,10 @@ export const HoverHoldOverlay: React.FC<HoverHoldOverlayProps> = ({
     outerR,
     startAngle: mid,
     endAngle,
+    innerStartAngle: innerMid,
+    innerEndAngle: iEnd,
+    outerStartAngle: outerMid,
+    outerEndAngle: oEnd,
   });
 
   // Posição dos labels: ângulo em 1/4 e 3/4 da fatia.
@@ -151,7 +181,18 @@ export const HoverHoldOverlay: React.FC<HoverHoldOverlayProps> = ({
   const yesY = cy + labelR * Math.sin(yesAngle);
   const noX = cx + labelR * Math.cos(noAngle);
   const noY = cy + labelR * Math.sin(noAngle);
-  const slicePath = arcPath({ cx, cy, innerR, outerR, startAngle, endAngle });
+  const slicePath = arcPath({
+    cx,
+    cy,
+    innerR,
+    outerR,
+    startAngle,
+    endAngle,
+    innerStartAngle: iStart,
+    innerEndAngle: iEnd,
+    outerStartAngle: oStart,
+    outerEndAngle: oEnd,
+  });
 
   const onActivate = (fn: () => void) => (e: React.KeyboardEvent) => {
     if (e.key === "Enter" || e.key === " ") {

--- a/src/donut/ProfileSwitcher.tsx
+++ b/src/donut/ProfileSwitcher.tsx
@@ -3,9 +3,9 @@ import type { Profile } from "../core/types/Profile";
 import { Slice } from "./Slice";
 import { IconRenderer } from "./IconRenderer";
 import {
-  OUTER_SLICE_ANGULAR_GAP_RAD,
+  OUTER_SLICE_GAP_PX,
   sliceAngleRange,
-  slicePaintRange,
+  slicePaintAngles,
 } from "./geometry";
 import { useSliceHighlight } from "./useSliceHighlight";
 
@@ -19,9 +19,9 @@ export interface ProfileSwitcherProps {
   onSelect: (profileId: string) => void;
   /** Click na fatia "+" — cria novo perfil. */
   onCreate: () => void;
-  /** Issue #58 — paridade com o modo "tabs". Quando `true` (default),
-   *  slices ganham gap angular cosmético via `slicePaintRange`. Hit-testing
-   *  permanece sobre o setor completo via `useSliceHighlight`. */
+  /** Issue #58 / #89 — paridade com o modo "tabs". Quando `true` (default),
+   *  slices ganham gap perpendicular constante via `slicePaintAngles`.
+   *  Hit-testing permanece sobre o setor completo via `useSliceHighlight`. */
   sliceGapEnabled?: boolean;
 }
 
@@ -47,7 +47,7 @@ export const ProfileSwitcher: React.FC<ProfileSwitcherProps> = ({
 }) => {
   const total = profiles.length + 1;
   const plusIndex = profiles.length;
-  const gap = sliceGapEnabled ? OUTER_SLICE_ANGULAR_GAP_RAD : 0;
+  const gapPx = sliceGapEnabled ? OUTER_SLICE_GAP_PX : 0;
 
   const { highlighted, onMouseMove, onMouseLeave } = useSliceHighlight({
     center: { x: cx, y: cy },
@@ -63,7 +63,7 @@ export const ProfileSwitcher: React.FC<ProfileSwitcherProps> = ({
       onMouseLeave={onMouseLeave}
     >
       {profiles.map((profile, i) => {
-        const { start, end } = slicePaintRange(i, total, gap);
+        const angles = slicePaintAngles(i, total, gapPx, innerR, outerR);
         const full = sliceAngleRange(i, total);
         const label = profile.name;
         const fallbackInitial =
@@ -76,8 +76,12 @@ export const ProfileSwitcher: React.FC<ProfileSwitcherProps> = ({
               cy={cy}
               innerR={innerR}
               outerR={outerR}
-              startAngle={start}
-              endAngle={end}
+              startAngle={angles.outerStart}
+              endAngle={angles.outerEnd}
+              innerStartAngle={angles.innerStart}
+              innerEndAngle={angles.innerEnd}
+              outerStartAngle={angles.outerStart}
+              outerEndAngle={angles.outerEnd}
               label={label}
               iconNode={
                 <IconRenderer
@@ -101,7 +105,7 @@ export const ProfileSwitcher: React.FC<ProfileSwitcherProps> = ({
         );
       })}
       {(() => {
-        const { start, end } = slicePaintRange(plusIndex, total, gap);
+        const angles = slicePaintAngles(plusIndex, total, gapPx, innerR, outerR);
         return (
           <Slice
             key={PLUS_KEY}
@@ -109,8 +113,12 @@ export const ProfileSwitcher: React.FC<ProfileSwitcherProps> = ({
             cy={cy}
             innerR={innerR}
             outerR={outerR}
-            startAngle={start}
-            endAngle={end}
+            startAngle={angles.outerStart}
+            endAngle={angles.outerEnd}
+            innerStartAngle={angles.innerStart}
+            innerEndAngle={angles.innerEnd}
+            outerStartAngle={angles.outerStart}
+            outerEndAngle={angles.outerEnd}
             icon="+"
             highlighted={highlighted === plusIndex}
             onClick={onCreate}

--- a/src/donut/Slice.tsx
+++ b/src/donut/Slice.tsx
@@ -6,6 +6,11 @@ export interface SliceProps {
   cx: number; cy: number;
   innerR: number; outerR: number;
   startAngle: number; endAngle: number;
+  /** Issue #89 — quando definidos, sobrescrevem `startAngle`/`endAngle`
+   *  para os corners correspondentes do path. Permite gap perpendicular
+   *  constante. Label/ícone continuam usando `(startAngle+endAngle)/2`. */
+  innerStartAngle?: number; innerEndAngle?: number;
+  outerStartAngle?: number; outerEndAngle?: number;
   label?: string;
   icon?: string;
   /** Optional rich icon node (e.g. <IconRenderer/>). When set, replaces the

--- a/src/donut/__tests__/ProfileSwitcher.test.tsx
+++ b/src/donut/__tests__/ProfileSwitcher.test.tsx
@@ -146,7 +146,7 @@ describe("ProfileSwitcher", () => {
     expect(texts).toContain("?");
   });
 
-  it("applies angular gap between slices when sliceGapEnabled=true", () => {
+  it("applies perpendicular gap between slices when sliceGapEnabled=true", () => {
     const profiles = [profile("a", "A"), profile("b", "B")];
     const { container } = renderInSvg(
       <ProfileSwitcher

--- a/src/donut/__tests__/geometry.test.ts
+++ b/src/donut/__tests__/geometry.test.ts
@@ -7,6 +7,7 @@ import {
   ringHitBounds,
   pointToRingIndex,
   slicePaintRange,
+  slicePaintAngles,
 } from "../geometry";
 
 describe("sliceAngleRange", () => {
@@ -222,5 +223,113 @@ describe("slicePaintRange", () => {
     expect(painted.start).toBeCloseTo(raw.start);
     expect(painted.end).toBeCloseTo(raw.end);
     expect(painted.end - painted.start).toBeCloseTo(Math.PI * 2);
+  });
+});
+
+describe("slicePaintAngles", () => {
+  it("gap=0 → todos os 4 ângulos casam com sliceAngleRange", () => {
+    const raw = sliceAngleRange(1, 4);
+    const a = slicePaintAngles(1, 4, 0, 80, 140);
+    expect(a.innerStart).toBeCloseTo(raw.start);
+    expect(a.innerEnd).toBeCloseTo(raw.end);
+    expect(a.outerStart).toBeCloseTo(raw.start);
+    expect(a.outerEnd).toBeCloseTo(raw.end);
+  });
+
+  it("n=1 retorna range completo nos 4 ângulos (anel fechado, sem fenda)", () => {
+    const raw = sliceAngleRange(0, 1);
+    const a = slicePaintAngles(0, 1, 6, 80, 140);
+    expect(a.innerStart).toBeCloseTo(raw.start);
+    expect(a.innerEnd).toBeCloseTo(raw.end);
+    expect(a.outerStart).toBeCloseTo(raw.start);
+    expect(a.outerEnd).toBeCloseTo(raw.end);
+    expect(a.outerEnd - a.outerStart).toBeCloseTo(Math.PI * 2);
+  });
+
+  it("gap perpendicular constante: arc-length do trim é ~g/2 em qualquer raio", () => {
+    const gap = 6;
+    const innerR = 80;
+    const outerR = 140;
+    const raw = sliceAngleRange(0, 4);
+    const a = slicePaintAngles(0, 4, gap, innerR, outerR);
+    // Cada lado é trimado de forma que a *distância perpendicular* equivalente
+    // ao trim no raio dado seja `gap/2`. `(α * r)` em um arco pequeno = `gap/2`,
+    // mas a regra exata é `r * sin(α) = gap/2` (asin invertido).
+    expect(innerR * Math.sin(a.innerStart - raw.start)).toBeCloseTo(gap / 2);
+    expect(outerR * Math.sin(a.outerStart - raw.start)).toBeCloseTo(gap / 2);
+    expect(innerR * Math.sin(raw.end - a.innerEnd)).toBeCloseTo(gap / 2);
+    expect(outerR * Math.sin(raw.end - a.outerEnd)).toBeCloseTo(gap / 2);
+  });
+
+  it("inner ganha mais trim angular que outer (mesma distância px)", () => {
+    const raw = sliceAngleRange(0, 4);
+    const a = slicePaintAngles(0, 4, 6, 80, 140);
+    const innerTrim = a.innerStart - raw.start;
+    const outerTrim = a.outerStart - raw.start;
+    expect(innerTrim).toBeGreaterThan(outerTrim);
+  });
+
+  it("midpoint preservado nos dois pares (slice continua centrada)", () => {
+    const raw = sliceAngleRange(2, 6);
+    const a = slicePaintAngles(2, 6, 6, 90, 150);
+    const rawMid = (raw.start + raw.end) / 2;
+    expect((a.innerStart + a.innerEnd) / 2).toBeCloseTo(rawMid);
+    expect((a.outerStart + a.outerEnd) / 2).toBeCloseTo(rawMid);
+  });
+
+  it("gap excessivo colapsa todos os 4 ângulos pro midpoint", () => {
+    // step = π/2 (n=4). Pra colapsar o inner (r pequeno) com gap absurdo:
+    const a = slicePaintAngles(1, 4, 1000, 10, 1000);
+    const raw = sliceAngleRange(1, 4);
+    const mid = (raw.start + raw.end) / 2;
+    expect(a.innerStart).toBeCloseTo(mid);
+    expect(a.innerEnd).toBeCloseTo(mid);
+    expect(a.outerStart).toBeCloseTo(mid);
+    expect(a.outerEnd).toBeCloseTo(mid);
+  });
+});
+
+describe("arcPath com 4 ângulos distintos", () => {
+  it("produz path SVG válido (M ... A ... L ... A ... Z) sem NaN", () => {
+    const raw = sliceAngleRange(0, 4);
+    const a = slicePaintAngles(0, 4, 6, 80, 140);
+    const d = arcPath({
+      cx: 100,
+      cy: 100,
+      innerR: 80,
+      outerR: 140,
+      startAngle: raw.start,
+      endAngle: raw.end,
+      innerStartAngle: a.innerStart,
+      innerEndAngle: a.innerEnd,
+      outerStartAngle: a.outerStart,
+      outerEndAngle: a.outerEnd,
+    });
+    expect(d).toMatch(/^M [\d.-]+ [\d.-]+ A .* A .* Z$/);
+    expect(d).not.toMatch(/NaN/);
+  });
+
+  it("sem overrides, cai no comportamento legado (corners iguais)", () => {
+    const legacy = arcPath({
+      cx: 0,
+      cy: 0,
+      innerR: 50,
+      outerR: 100,
+      startAngle: 0,
+      endAngle: Math.PI / 2,
+    });
+    const explicit = arcPath({
+      cx: 0,
+      cy: 0,
+      innerR: 50,
+      outerR: 100,
+      startAngle: 0,
+      endAngle: Math.PI / 2,
+      innerStartAngle: 0,
+      innerEndAngle: Math.PI / 2,
+      outerStartAngle: 0,
+      outerEndAngle: Math.PI / 2,
+    });
+    expect(explicit).toBe(legacy);
   });
 });

--- a/src/donut/geometry.ts
+++ b/src/donut/geometry.ts
@@ -45,6 +45,69 @@ export function slicePaintRange(
   return { start: newStart, end: newEnd };
 }
 
+/**
+ * Issue #89 — versão "pixel-perpendicular" de `slicePaintRange`.
+ * Retorna 4 ângulos (corners inner/outer) calculados de forma que o
+ * gap *perpendicular* entre slices vizinhos seja constante em px do
+ * raio interno ao externo. No raio `r` o offset angular necessário
+ * pra conseguir um deslocamento perpendicular `g/2` é `asin(g/(2r))`
+ * — maior no inner, menor no outer.
+ *
+ * Casos especiais:
+ *  - `n <= 1` → retorna o range completo nos 4 campos (anel fechado,
+ *    sem fenda — mesma regra que `slicePaintRange`).
+ *  - `gapPx <= 0` → todos os 4 ângulos casam com `sliceAngleRange`.
+ *  - Gap excessivo (resultaria em range invertido em qualquer raio) →
+ *    colapsa os 4 ângulos no midpoint da slice (defensivo).
+ *
+ * Hit-test deve continuar usando `pointToSliceIndex` (range completo) —
+ * o respiro é só visual.
+ *
+ * Pure pra teste.
+ */
+export interface SlicePaintAngles {
+  innerStart: number;
+  innerEnd: number;
+  outerStart: number;
+  outerEnd: number;
+}
+
+export function slicePaintAngles(
+  index: number,
+  n: number,
+  gapPx: number,
+  innerR: number,
+  outerR: number,
+): SlicePaintAngles {
+  const raw = sliceAngleRange(index, n);
+  if (n <= 1 || gapPx <= 0) {
+    return {
+      innerStart: raw.start,
+      innerEnd: raw.end,
+      outerStart: raw.start,
+      outerEnd: raw.end,
+    };
+  }
+  const halfGap = gapPx / 2;
+  const angleAt = (r: number): number => {
+    if (r <= 0) return Math.PI / 2;
+    const ratio = halfGap / r;
+    if (ratio >= 1) return Math.PI / 2;
+    return Math.asin(ratio);
+  };
+  const innerAlpha = angleAt(innerR);
+  const outerAlpha = angleAt(outerR);
+  const innerStart = raw.start + innerAlpha;
+  const innerEnd = raw.end - innerAlpha;
+  const outerStart = raw.start + outerAlpha;
+  const outerEnd = raw.end - outerAlpha;
+  if (innerEnd <= innerStart || outerEnd <= outerStart) {
+    const mid = (raw.start + raw.end) / 2;
+    return { innerStart: mid, innerEnd: mid, outerStart: mid, outerEnd: mid };
+  }
+  return { innerStart, innerEnd, outerStart, outerEnd };
+}
+
 export interface SliceLookupOpts {
   innerRadius?: number;
   outerRadius?: number;
@@ -66,6 +129,13 @@ export interface ArcPathOpts {
   cx: number; cy: number;
   innerR: number; outerR: number;
   startAngle: number; endAngle: number;
+  /** Issue #89 — quando definidos, os 4 ângulos abaixo sobrescrevem
+   *  `startAngle`/`endAngle` para os corners correspondentes. Permite
+   *  que a borda inner e outer da slice tenham trims angulares diferentes
+   *  pra um gap perpendicular constante. Ausência cai no comportamento
+   *  legado (mesma start/end nos dois arcos). */
+  innerStartAngle?: number; innerEndAngle?: number;
+  outerStartAngle?: number; outerEndAngle?: number;
 }
 
 export interface RingDims {
@@ -80,11 +150,18 @@ export const OUTER_RING_BAND_WIDTH = 60;
  *  região de "no-hit" no `pointToRingIndex` (cursor entre anéis não casa
  *  nenhum). */
 export const RING_GAP = 4;
-/** Plano 23 — gap angular (radianos) entre slices vizinhos em anéis
- *  externos (ring 1+). Encolhe a pintura de cada slice em metade desse
- *  valor de cada lado. Hit-test mantém range completo (sem deadzone),
- *  só a pintura tem o respiro. ~2.3° (0.04 rad). */
+/** Plano 23 — gap angular (radianos) entre slices vizinhos. Helper
+ *  legado `slicePaintRange` ainda usa essa unidade. A pintura nova
+ *  (`slicePaintAngles`) usa gap em pixels perpendicular constante
+ *  (`OUTER_SLICE_GAP_PX`). Mantido pra back-compat de callers e testes. */
 export const OUTER_SLICE_ANGULAR_GAP_RAD = 0.04;
+
+/** Issue #89 — gap perpendicular (px) entre slices vizinhos, constante do
+ *  raio interno ao externo. Substitui o gap angular (que crescia em arc
+ *  length conforme o raio). Resolvido em ângulo via `asin(g/(2r))` —
+ *  ângulo maior no inner, menor no outer, resultando em borda visualmente
+ *  reta de largura uniforme. */
+export const OUTER_SLICE_GAP_PX = 6;
 
 /**
  * Plano 23 — calcula os raios de cada anel concêntrico para **pintura**
@@ -190,20 +267,29 @@ export function arcPath(o: ArcPathOpts): string {
     ].join(" ");
   }
 
-  const largeArc = delta > Math.PI ? 1 : 0;
-  const x1 = cx + outerR * Math.cos(startAngle);
-  const y1 = cy + outerR * Math.sin(startAngle);
-  const x2 = cx + outerR * Math.cos(endAngle);
-  const y2 = cy + outerR * Math.sin(endAngle);
-  const x3 = cx + innerR * Math.cos(endAngle);
-  const y3 = cy + innerR * Math.sin(endAngle);
-  const x4 = cx + innerR * Math.cos(startAngle);
-  const y4 = cy + innerR * Math.sin(startAngle);
+  // Issue #89 — corners inner/outer podem ter ângulos diferentes para
+  // realizar um gap perpendicular constante. `largeArc` é resolvido
+  // por arc, já que o trim assimétrico pode flippar a flag no canto do
+  // step entre as duas bandas.
+  const oStart = o.outerStartAngle ?? startAngle;
+  const oEnd = o.outerEndAngle ?? endAngle;
+  const iStart = o.innerStartAngle ?? startAngle;
+  const iEnd = o.innerEndAngle ?? endAngle;
+  const outerLargeArc = oEnd - oStart > Math.PI ? 1 : 0;
+  const innerLargeArc = iEnd - iStart > Math.PI ? 1 : 0;
+  const x1 = cx + outerR * Math.cos(oStart);
+  const y1 = cy + outerR * Math.sin(oStart);
+  const x2 = cx + outerR * Math.cos(oEnd);
+  const y2 = cy + outerR * Math.sin(oEnd);
+  const x3 = cx + innerR * Math.cos(iEnd);
+  const y3 = cy + innerR * Math.sin(iEnd);
+  const x4 = cx + innerR * Math.cos(iStart);
+  const y4 = cy + innerR * Math.sin(iStart);
   return [
     `M ${x1} ${y1}`,
-    `A ${outerR} ${outerR} 0 ${largeArc} 1 ${x2} ${y2}`,
+    `A ${outerR} ${outerR} 0 ${outerLargeArc} 1 ${x2} ${y2}`,
     `L ${x3} ${y3}`,
-    `A ${innerR} ${innerR} 0 ${largeArc} 0 ${x4} ${y4}`,
+    `A ${innerR} ${innerR} 0 ${innerLargeArc} 0 ${x4} ${y4}`,
     "Z",
   ].join(" ");
 }

--- a/src/settings/MiniDonutPreview.tsx
+++ b/src/settings/MiniDonutPreview.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { arcPath, sliceAngleRange } from "../donut/geometry";
+import { arcPath, OUTER_SLICE_GAP_PX, slicePaintAngles } from "../donut/geometry";
 import type { ThemeTokens } from "../core/themeTokens";
 
 export interface MiniDonutPreviewProps {
@@ -35,10 +35,21 @@ export const MiniDonutPreview: React.FC<MiniDonutPreviewProps> = ({
       viewBox={`0 0 ${size} ${size}`}
     >
       {DUMMY_LABELS.map((label, i) => {
-        const { start, end } = sliceAngleRange(i, total);
-        const d = arcPath({ cx, cy, innerR, outerR, startAngle: start, endAngle: end });
+        const angles = slicePaintAngles(i, total, OUTER_SLICE_GAP_PX, innerR, outerR);
+        const d = arcPath({
+          cx,
+          cy,
+          innerR,
+          outerR,
+          startAngle: angles.outerStart,
+          endAngle: angles.outerEnd,
+          innerStartAngle: angles.innerStart,
+          innerEndAngle: angles.innerEnd,
+          outerStartAngle: angles.outerStart,
+          outerEndAngle: angles.outerEnd,
+        });
         const isHighlighted = i === 0;
-        const mid = (start + end) / 2;
+        const mid = (angles.outerStart + angles.outerEnd) / 2;
         const labelR = (innerR + outerR) / 2;
         const lx = cx + labelR * Math.cos(mid);
         const ly = cy + labelR * Math.sin(mid);


### PR DESCRIPTION
## Summary
- Fecha #89. Antes o respiro entre slices crescia do raio interno pro externo (gap angular fixo × raio = arco maior na borda). Agora o gap é uma distância perpendicular constante em px, calculada via `asin(g/(2r))` por raio — a borda entre slices vira uma faixa de largura uniforme do inner ao outer.
- Novo helper puro `slicePaintAngles(index, n, gapPx, innerR, outerR)` retorna 4 ângulos (corners inner/outer); `arcPath` foi estendido pra aceitar ângulos inner/outer independentes (com `largeArc` resolvido por arco). `HoverHoldOverlay` usa midpoints duplos no split edit/delete; `MiniDonutPreview` reflete o gap real.
- Constante nova `OUTER_SLICE_GAP_PX = 6` substitui `OUTER_SLICE_ANGULAR_GAP_RAD` nas call sites de pintura. O angular continua exportado pra back-compat de `slicePaintRange` e seus testes.

## Test plan
- [x] `npx tsc --noEmit` limpo
- [x] `npm test` — 50 arquivos, 563 testes (incluindo 6 novos cobrindo `slicePaintAngles` e 2 cobrindo `arcPath` com 4 ângulos)
- [ ] Smoke visual (`npm run tauri dev`): perfil com ≥4 abas — confirmar a olho que o gap tem largura constante na borda interna e externa do ring root
- [ ] Smoke visual: drillar num group e validar o mesmo gap no ring externo (`OUTER_RING_BAND_WIDTH = 60`)
- [ ] Smoke visual: hover-hold numa aba — overlay edit/delete cobre o slice sem deixar tira do slice original aparecendo
- [ ] Smoke visual: Settings → Aparência → Theme customizer — preview espelha o gap real

🤖 Generated with [Claude Code](https://claude.com/claude-code)