### PR TITLE
feat(settings): diferencia criação de aba dentro de grupo (#103)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -286,7 +286,7 @@
     },
     "editor": {
       "newTabTitle": "New tab",
-      "newTabInGroupSubtitle": "Creating tab inside the “{{groupName}}” group.",
+      "newTabInGroupAria": "Creating tab inside the “{{groupName}}” group.",
       "name": "Name",
       "namePlaceholder": "Work",
       "icon": "Icon",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -286,6 +286,7 @@
     },
     "editor": {
       "newTabTitle": "New tab",
+      "newTabInGroupSubtitle": "Creating tab inside the “{{groupName}}” group.",
       "name": "Name",
       "namePlaceholder": "Work",
       "icon": "Icon",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -286,6 +286,7 @@
     },
     "editor": {
       "newTabTitle": "Nueva pestaña",
+      "newTabInGroupSubtitle": "Creando pestaña dentro del grupo “{{groupName}}”.",
       "name": "Nombre",
       "namePlaceholder": "Trabajo",
       "icon": "Icono",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -286,7 +286,7 @@
     },
     "editor": {
       "newTabTitle": "Nueva pestaña",
-      "newTabInGroupSubtitle": "Creando pestaña dentro del grupo “{{groupName}}”.",
+      "newTabInGroupAria": "Creando pestaña dentro del grupo “{{groupName}}”.",
       "name": "Nombre",
       "namePlaceholder": "Trabajo",
       "icon": "Icono",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -286,6 +286,7 @@
     },
     "editor": {
       "newTabTitle": "Nouvel onglet",
+      "newTabInGroupSubtitle": "Création d’un onglet dans le groupe « {{groupName}} ».",
       "name": "Nom",
       "namePlaceholder": "Travail",
       "icon": "Icône",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -286,7 +286,7 @@
     },
     "editor": {
       "newTabTitle": "Nouvel onglet",
-      "newTabInGroupSubtitle": "Création d’un onglet dans le groupe « {{groupName}} ».",
+      "newTabInGroupAria": "Création d’un onglet dans le groupe « {{groupName}} ».",
       "name": "Nom",
       "namePlaceholder": "Travail",
       "icon": "Icône",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -286,7 +286,7 @@
     },
     "editor": {
       "newTabTitle": "Nuova scheda",
-      "newTabInGroupSubtitle": "Creazione di una scheda nel gruppo “{{groupName}}”.",
+      "newTabInGroupAria": "Creazione di una scheda nel gruppo “{{groupName}}”.",
       "name": "Nome",
       "namePlaceholder": "Lavoro",
       "icon": "Icona",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -286,6 +286,7 @@
     },
     "editor": {
       "newTabTitle": "Nuova scheda",
+      "newTabInGroupSubtitle": "Creazione di una scheda nel gruppo “{{groupName}}”.",
       "name": "Nome",
       "namePlaceholder": "Lavoro",
       "icon": "Icona",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -286,7 +286,7 @@
     },
     "editor": {
       "newTabTitle": "新規タブ",
-      "newTabInGroupSubtitle": "「{{groupName}}」グループ内にタブを作成しています。",
+      "newTabInGroupAria": "「{{groupName}}」グループ内にタブを作成しています。",
       "name": "名前",
       "namePlaceholder": "仕事",
       "icon": "アイコン",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -286,6 +286,7 @@
     },
     "editor": {
       "newTabTitle": "新規タブ",
+      "newTabInGroupSubtitle": "「{{groupName}}」グループ内にタブを作成しています。",
       "name": "名前",
       "namePlaceholder": "仕事",
       "icon": "アイコン",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -286,7 +286,7 @@
     },
     "editor": {
       "newTabTitle": "Nova aba",
-      "newTabInGroupSubtitle": "Criando aba dentro do grupo “{{groupName}}”.",
+      "newTabInGroupAria": "Criando aba dentro do grupo “{{groupName}}”.",
       "name": "Nome",
       "namePlaceholder": "Trabalho",
       "icon": "Ícone",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -286,6 +286,7 @@
     },
     "editor": {
       "newTabTitle": "Nova aba",
+      "newTabInGroupSubtitle": "Criando aba dentro do grupo “{{groupName}}”.",
       "name": "Nome",
       "namePlaceholder": "Trabalho",
       "icon": "Ícone",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -286,7 +286,7 @@
     },
     "editor": {
       "newTabTitle": "Новая вкладка",
-      "newTabInGroupSubtitle": "Создание вкладки внутри группы «{{groupName}}».",
+      "newTabInGroupAria": "Создание вкладки внутри группы «{{groupName}}».",
       "name": "Имя",
       "namePlaceholder": "Работа",
       "icon": "Значок",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -286,6 +286,7 @@
     },
     "editor": {
       "newTabTitle": "Новая вкладка",
+      "newTabInGroupSubtitle": "Создание вкладки внутри группы «{{groupName}}».",
       "name": "Имя",
       "namePlaceholder": "Работа",
       "icon": "Значок",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -286,6 +286,7 @@
     },
     "editor": {
       "newTabTitle": "新建标签页",
+      "newTabInGroupSubtitle": "正在“{{groupName}}”组内创建标签页。",
       "name": "名称",
       "namePlaceholder": "工作",
       "icon": "图标",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -286,7 +286,7 @@
     },
     "editor": {
       "newTabTitle": "新建标签页",
-      "newTabInGroupSubtitle": "正在“{{groupName}}”组内创建标签页。",
+      "newTabInGroupAria": "正在“{{groupName}}”组内创建标签页。",
       "name": "名称",
       "namePlaceholder": "工作",
       "icon": "图标",

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -315,6 +315,17 @@ export const SettingsApp: React.FC = () => {
 
   const currentDepth = (currentParentPath?.length ?? 0) + 1;
 
+  // Issue #103 — nome do grupo-pai imediato (último id do path) pra exibir como
+  // subtítulo na tela de criação de aba dentro de um grupo.
+  const parentGroupName: string | null =
+    currentParentPath && currentParentPath.length > 0
+      ? (() => {
+          const lastId = currentParentPath[currentParentPath.length - 1];
+          const found = findTabPathInProfile(selectedProfile.tabs, lastId);
+          return found ? found.tab.name ?? found.tab.icon ?? null : null;
+        })()
+      : null;
+
   const handleSave = async (tab: Tab) => {
     await saveTab(tab, selectedProfile.id, currentParentPath);
     setSelection({ mode: "edit", tabId: tab.id, parentPath: currentParentPath });
@@ -427,6 +438,7 @@ export const SettingsApp: React.FC = () => {
               onDelete={handleDelete}
               currentDepth={currentDepth}
               initialKind={selection.suggestedKind ?? "leaf"}
+              parentGroupName={parentGroupName}
             />
           ) : selection.mode === "edit" && selectedTab ? (
             <TabEditor

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -315,14 +315,14 @@ export const SettingsApp: React.FC = () => {
 
   const currentDepth = (currentParentPath?.length ?? 0) + 1;
 
-  // Issue #103 — nome do grupo-pai imediato (último id do path) pra exibir como
-  // subtítulo na tela de criação de aba dentro de um grupo.
-  const parentGroupName: string | null =
+  // Issue #103 — grupo-pai imediato (último id do path) pra exibir como
+  // cabeçalho (ícone + nome) na tela de criação de aba dentro de um grupo.
+  const parentGroup: { name: string | null; icon: string | null } | null =
     currentParentPath && currentParentPath.length > 0
       ? (() => {
           const lastId = currentParentPath[currentParentPath.length - 1];
           const found = findTabPathInProfile(selectedProfile.tabs, lastId);
-          return found ? found.tab.name ?? found.tab.icon ?? null : null;
+          return found ? { name: found.tab.name, icon: found.tab.icon } : null;
         })()
       : null;
 
@@ -438,7 +438,7 @@ export const SettingsApp: React.FC = () => {
               onDelete={handleDelete}
               currentDepth={currentDepth}
               initialKind={selection.suggestedKind ?? "leaf"}
-              parentGroupName={parentGroupName}
+              parentGroup={parentGroup}
             />
           ) : selection.mode === "edit" && selectedTab ? (
             <TabEditor

--- a/src/settings/TabEditor.tsx
+++ b/src/settings/TabEditor.tsx
@@ -6,6 +6,7 @@ import { translateAppError } from "../core/errors";
 import { graphemeCount } from "./textUtils";
 import { IconPicker } from "./IconPicker";
 import { IconField } from "./IconField";
+import { IconDisplay } from "./IconDisplay";
 import { Switch } from "./Switch";
 import type { Tab } from "../core/types/Tab";
 import type { Item } from "../core/types/Item";
@@ -46,9 +47,10 @@ export interface TabEditorProps {
   /** Plano 16 — pré-seleciona o radio "Aba" / "Grupo" no modo new.
    *  Ignorado em mode=edit (kind é deduzido de `initial.children`). */
   initialKind?: TabKind;
-  /** Issue #103 — nome do grupo-pai quando criando uma aba dentro de um grupo
-   *  (mode=new + currentDepth > 1). Exibido como subtítulo; `null` no root. */
-  parentGroupName?: string | null;
+  /** Issue #103 — grupo-pai quando criando uma aba dentro de um grupo
+   *  (mode=new + currentDepth > 1). Renderizado como cabeçalho (ícone + nome)
+   *  acima do título "Nova aba"; `null` no root. */
+  parentGroup?: { name: string | null; icon: string | null } | null;
 }
 
 interface FormState {
@@ -197,7 +199,7 @@ export const TabEditor: React.FC<TabEditorProps> = ({
   onSelectChild,
   onAddChild,
   initialKind = "leaf",
-  parentGroupName = null,
+  parentGroup = null,
 }) => {
   const { t } = useTranslation();
   // Issue #103 — dentro de um grupo (currentDepth > 1) só é possível criar
@@ -331,15 +333,25 @@ export const TabEditor: React.FC<TabEditorProps> = ({
         overflow: "auto",
       }}
     >
-      <h2 style={{ margin: 0 }}>{title}</h2>
-      {mode === "new" && parentGroupName && (
-        <p
-          data-testid="new-tab-in-group-subtitle"
-          style={{ margin: 0, color: "var(--muted)" }}
+      {mode === "new" && parentGroup && (
+        <div
+          data-testid="new-tab-in-group-header"
+          aria-label={t("settings.editor.newTabInGroupAria", {
+            groupName: parentGroup.name ?? parentGroup.icon ?? "",
+          })}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            fontWeight: 600,
+            fontSize: "1.1em",
+          }}
         >
-          {t("settings.editor.newTabInGroupSubtitle", { groupName: parentGroupName })}
-        </p>
+          {parentGroup.icon && <IconDisplay icon={parentGroup.icon} size={22} />}
+          {parentGroup.name && <span>{parentGroup.name}</span>}
+        </div>
       )}
+      <h2 style={{ margin: 0 }}>{title}</h2>
 
       <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
         <span>{t("settings.editor.name")}</span>

--- a/src/settings/TabEditor.tsx
+++ b/src/settings/TabEditor.tsx
@@ -46,6 +46,9 @@ export interface TabEditorProps {
   /** Plano 16 — pré-seleciona o radio "Aba" / "Grupo" no modo new.
    *  Ignorado em mode=edit (kind é deduzido de `initial.children`). */
   initialKind?: TabKind;
+  /** Issue #103 — nome do grupo-pai quando criando uma aba dentro de um grupo
+   *  (mode=new + currentDepth > 1). Exibido como subtítulo; `null` no root. */
+  parentGroupName?: string | null;
 }
 
 interface FormState {
@@ -194,19 +197,27 @@ export const TabEditor: React.FC<TabEditorProps> = ({
   onSelectChild,
   onAddChild,
   initialKind = "leaf",
+  parentGroupName = null,
 }) => {
   const { t } = useTranslation();
-  const [state, setState] = useState<FormState>(() => fromTab(initial, initialKind));
+  // Issue #103 — dentro de um grupo (currentDepth > 1) só é possível criar
+  // aba (leaf); o tipo "Grupo" seria inútil (MAX_TAB_DEPTH = 2). Forçamos leaf
+  // como kind inicial pra evitar um estado "group" órfão vindo de initialKind.
+  const insideGroup = currentDepth > 1;
+  const effectiveInitialKind: TabKind = insideGroup ? "leaf" : initialKind;
+  const [state, setState] = useState<FormState>(() =>
+    fromTab(initial, effectiveInitialKind),
+  );
   const [validation, setValidation] = useState<string | null>(null);
   const [serverError, setServerError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
 
   useEffect(() => {
-    setState(fromTab(initial, initialKind));
+    setState(fromTab(initial, effectiveInitialKind));
     setValidation(null);
     setServerError(null);
-  }, [initial, mode, initialKind]);
+  }, [initial, mode, effectiveInitialKind]);
 
   const submit = async () => {
     setServerError(null);
@@ -321,6 +332,14 @@ export const TabEditor: React.FC<TabEditorProps> = ({
       }}
     >
       <h2 style={{ margin: 0 }}>{title}</h2>
+      {mode === "new" && parentGroupName && (
+        <p
+          data-testid="new-tab-in-group-subtitle"
+          style={{ margin: 0, color: "var(--muted)" }}
+        >
+          {t("settings.editor.newTabInGroupSubtitle", { groupName: parentGroupName })}
+        </p>
+      )}
 
       <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
         <span>{t("settings.editor.name")}</span>
@@ -410,7 +429,7 @@ export const TabEditor: React.FC<TabEditorProps> = ({
         </div>
       )}
 
-      {mode === "new" && (
+      {mode === "new" && !insideGroup && (
         <fieldset
           style={{ border: "1px solid var(--input-border)", borderRadius: 4, padding: 12 }}
         >

--- a/src/settings/__tests__/TabEditor.test.tsx
+++ b/src/settings/__tests__/TabEditor.test.tsx
@@ -410,16 +410,21 @@ describe("TabEditor", () => {
     expect(screen.queryByTestId("group-new-hint")).toBeNull();
   });
 
-  it("shows a subtitle naming the parent group when creating inside it", async () => {
-    // Issue #103 — indicação visual de qual grupo está recebendo a aba.
-    await renderEditor({ mode: "new", currentDepth: 2, parentGroupName: "Trabalho" });
-    const subtitle = screen.getByTestId("new-tab-in-group-subtitle");
-    expect(subtitle.textContent).toContain("Trabalho");
+  it("shows a header naming the parent group when creating inside it", async () => {
+    // Issue #103 — indicação visual (ícone + nome) de qual grupo recebe a aba,
+    // renderizada acima do título "Nova aba".
+    await renderEditor({
+      mode: "new",
+      currentDepth: 2,
+      parentGroup: { name: "Trabalho", icon: "💼" },
+    });
+    const header = screen.getByTestId("new-tab-in-group-header");
+    expect(header.textContent).toContain("Trabalho");
   });
 
-  it("does not show the group subtitle at root level", async () => {
+  it("does not show the group header at root level", async () => {
     await renderEditor({ mode: "new", currentDepth: 1 });
-    expect(screen.queryByTestId("new-tab-in-group-subtitle")).toBeNull();
+    expect(screen.queryByTestId("new-tab-in-group-header")).toBeNull();
   });
 
   it("preserves kind=group when re-editing an empty group (regression)", async () => {

--- a/src/settings/__tests__/TabEditor.test.tsx
+++ b/src/settings/__tests__/TabEditor.test.tsx
@@ -393,6 +393,35 @@ describe("TabEditor", () => {
     expect(payload.children).toEqual([]);
   });
 
+  it("shows the kind radio at root level (currentDepth=1)", async () => {
+    // Issue #103 — no root o usuário ainda escolhe Aba vs Grupo.
+    await renderEditor({ mode: "new", currentDepth: 1 });
+    expect(screen.queryByTestId("tab-kind-leaf")).toBeTruthy();
+    expect(screen.queryByTestId("tab-kind-group")).toBeTruthy();
+  });
+
+  it("hides the kind radio inside a group (currentDepth>1) and renders the leaf item editor", async () => {
+    // Issue #103 — dentro de um grupo só é possível criar aba (leaf); o tipo
+    // "Grupo" some e o ItemListEditor (leaf) é renderizado direto.
+    await renderEditor({ mode: "new", currentDepth: 2 });
+    expect(screen.queryByTestId("tab-kind-leaf")).toBeNull();
+    expect(screen.queryByTestId("tab-kind-group")).toBeNull();
+    expect(screen.getByLabelText(/url 1/i)).toBeTruthy();
+    expect(screen.queryByTestId("group-new-hint")).toBeNull();
+  });
+
+  it("shows a subtitle naming the parent group when creating inside it", async () => {
+    // Issue #103 — indicação visual de qual grupo está recebendo a aba.
+    await renderEditor({ mode: "new", currentDepth: 2, parentGroupName: "Trabalho" });
+    const subtitle = screen.getByTestId("new-tab-in-group-subtitle");
+    expect(subtitle.textContent).toContain("Trabalho");
+  });
+
+  it("does not show the group subtitle at root level", async () => {
+    await renderEditor({ mode: "new", currentDepth: 1 });
+    expect(screen.queryByTestId("new-tab-in-group-subtitle")).toBeNull();
+  });
+
   it("preserves kind=group when re-editing an empty group (regression)", async () => {
     const emptyGroup: Tab = {
       id: "22222222-2222-2222-2222-222222222222",


### PR DESCRIPTION
Resolve a issue #103: a tela de criação de aba dentro de um grupo agora é distinta da criação no nível root. Dentro de um grupo, o `<TabEditor>` esconde o radio "Aba | Grupo" (apenas aba/leaf é possível, já que `MAX_TAB_DEPTH=2`) e exibe um subtítulo indicando o grupo de destino, resolvido via `findTabPathInProfile` em `SettingsApp`. Adicionada a chave `settings.editor.newTabInGroupSubtitle` nos 8 idiomas (paridade de locales) e uma salvaguarda que força `kind: "leaf"` dentro de grupo. Inclui 4 testes novos cobrindo radio escondido/visível e a presença/ausência do subtítulo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
