### PR TITLE
feat(settings): tutorial apresenta os 9 idiomas (#106)

### DIFF
--- a/src/settings/SystemSection.tsx
+++ b/src/settings/SystemSection.tsx
@@ -4,6 +4,7 @@ import type { Language } from "../core/types/Language";
 import type { SpawnPosition } from "../core/types/SpawnPosition";
 import { groupStyle, legendStyle } from "./fieldsetStyles";
 import { Switch } from "./Switch";
+import { LANGUAGE_OPTIONS } from "./languageOptions";
 
 export interface SystemSectionProps {
   language: Language;
@@ -95,15 +96,11 @@ export const SystemSection: React.FC<SystemSectionProps> = ({
               font: "inherit",
             }}
           >
-            <option value="auto">{t("settings.appearance.languageAuto")}</option>
-            <option value="ptBr">{t("settings.appearance.languagePtBr")}</option>
-            <option value="en">{t("settings.appearance.languageEn")}</option>
-            <option value="es">{t("settings.appearance.languageEs")}</option>
-            <option value="zh">{t("settings.appearance.languageZh")}</option>
-            <option value="ja">{t("settings.appearance.languageJa")}</option>
-            <option value="ru">{t("settings.appearance.languageRu")}</option>
-            <option value="fr">{t("settings.appearance.languageFr")}</option>
-            <option value="it">{t("settings.appearance.languageIt")}</option>
+            {LANGUAGE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {t(opt.labelKey)}
+              </option>
+            ))}
           </select>
         </label>
 

--- a/src/settings/Wizard.tsx
+++ b/src/settings/Wizard.tsx
@@ -4,6 +4,7 @@ import type { Section } from "./SectionTabs";
 import type { Language } from "../core/types/Language";
 import type { SpawnPosition } from "../core/types/SpawnPosition";
 import { WIZARD_MEDIA, isVideoSrc } from "./wizardMedia";
+import { LANGUAGE_OPTIONS } from "./languageOptions";
 
 type SectionStepId =
   | "welcome"
@@ -472,9 +473,11 @@ export const Wizard: React.FC<WizardProps> = ({
                     font: "inherit",
                   }}
                 >
-                  <option value="auto">{t("settings.appearance.languageAuto")}</option>
-                  <option value="ptBr">{t("settings.appearance.languagePtBr")}</option>
-                  <option value="en">{t("settings.appearance.languageEn")}</option>
+                  {LANGUAGE_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {t(opt.labelKey)}
+                    </option>
+                  ))}
                 </select>
               </label>
               <label

--- a/src/settings/__tests__/Wizard.test.tsx
+++ b/src/settings/__tests__/Wizard.test.tsx
@@ -118,6 +118,20 @@ describe("Wizard", () => {
       await user.click(screen.getByTestId("wizard-next"));
     }
     expect(screen.getByTestId("wizard-card-system")).toBeTruthy();
+    // Issue #106: o seletor do tutorial deve oferecer os 9 idiomas (não só auto/ptBr/en).
+    const languageSelect = screen.getByTestId("wizard-language") as HTMLSelectElement;
+    const optionValues = Array.from(languageSelect.options).map((o) => o.value);
+    expect(optionValues).toEqual([
+      "auto",
+      "ptBr",
+      "en",
+      "es",
+      "zh",
+      "ja",
+      "ru",
+      "fr",
+      "it",
+    ]);
     await user.click(screen.getByTestId("wizard-autostart"));
     expect(onAutostartChange).toHaveBeenCalledWith(true);
     await user.click(screen.getByTestId("wizard-allow-scripts"));

--- a/src/settings/languageOptions.ts
+++ b/src/settings/languageOptions.ts
@@ -1,0 +1,14 @@
+import type { Language } from "../core/types/Language";
+
+/** Ordem canônica das opções de idioma; `labelKey` resolve via t(). */
+export const LANGUAGE_OPTIONS: ReadonlyArray<{ value: Language; labelKey: string }> = [
+  { value: "auto", labelKey: "settings.appearance.languageAuto" },
+  { value: "ptBr", labelKey: "settings.appearance.languagePtBr" },
+  { value: "en", labelKey: "settings.appearance.languageEn" },
+  { value: "es", labelKey: "settings.appearance.languageEs" },
+  { value: "zh", labelKey: "settings.appearance.languageZh" },
+  { value: "ja", labelKey: "settings.appearance.languageJa" },
+  { value: "ru", labelKey: "settings.appearance.languageRu" },
+  { value: "fr", labelKey: "settings.appearance.languageFr" },
+  { value: "it", labelKey: "settings.appearance.languageIt" },
+];


### PR DESCRIPTION
## Contexto

Resolve a issue #106. O seletor de idioma do **tutorial de primeiro uso** (`Wizard.tsx`, passo "Sistema") só oferecia 3 opções (`auto`, `ptBr`, `en`), enquanto o seletor de **Settings → Sistema** já listava os 9 idiomas adicionados no #100. No onboarding o usuário só conseguia escolher inglês ou português; os 6 idiomas novos (es, zh, ja, ru, fr, it) ficavam escondidos.

A causa raiz era a **duplicação** da lista de `<option>` entre os dois componentes — eles divergiram.

## Mudanças

- **`src/settings/languageOptions.ts`** (novo) — constante `LANGUAGE_OPTIONS` como fonte única da lista (`{ value, labelKey }`), reaproveitando chaves de tradução já existentes.
- **`src/settings/Wizard.tsx`** — substitui as 3 `<option>` hardcoded por `.map(LANGUAGE_OPTIONS)`. Agora o tutorial apresenta os 9 idiomas. ✅ (corrige a issue)
- **`src/settings/SystemSection.tsx`** — usa a mesma constante (remove duplicação; comportamento inalterado).
- **`src/settings/__tests__/Wizard.test.tsx`** — asserção travando a regressão: o select do wizard expõe exatamente os 9 idiomas na ordem canônica.

Nenhuma string nova de tradução necessária — as chaves `settings.appearance.language*` já existem nos 8 locales.

## Verificação

- `npx tsc --noEmit` → OK
- `npm test` → 586 testes passando (50 arquivos)

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
